### PR TITLE
build: update rmcp dependency to version 0.1.5

### DIFF
--- a/swarms-rs/Cargo.toml
+++ b/swarms-rs/Cargo.toml
@@ -46,8 +46,8 @@ reqwest = { version = "0.12", features = [
 # LLM provider
 async-openai = { version = "0.28", features = ["byot"] }
 
-# MCP, keep latest version for now
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+# MCP
+rmcp = { version = "0.1.5", features = [
     "client",
     "transport-sse",
     "transport-child-process",

--- a/swarms-rs/src/structs/tool.rs
+++ b/swarms-rs/src/structs/tool.rs
@@ -157,10 +157,11 @@ impl Tool for MCPTool {
                         blob
                     ),
                 },
-                rmcp::model::RawContent::Audio(annotated) => format!(
-                    "data:{};base64,{}",
-                    annotated.raw.mime_type, annotated.raw.data
-                ),
+                // TODO: latest version should uncomment the following line, but now we use old version
+                // rmcp::model::RawContent::Audio(annotated) => format!(
+                //     "data:{};base64,{}",
+                //     annotated.raw.mime_type, annotated.raw.data
+                // ),
             })
             .collect::<Vec<_>>()
             .join(""))
@@ -177,7 +178,8 @@ impl From<&rmcp::model::Tool> for ToolDefinition {
         let description = value
             .to_owned()
             .description
-            .unwrap_or(name.clone().into())
+            // TODO: latest version should uncomment the following line, but now we use old version
+            // .unwrap_or(name.clone().into())
             .to_string();
         let parameters = serde_json::Value::Object(value.input_schema.deref().to_owned());
 


### PR DESCRIPTION
Update the rmcp dependency from the latest git branch to version 0.1.5 to ensure stability and compatibility. Temporarily comment out code related to audio handling and description unwrapping to align with the older version of rmcp being used.