### PR TITLE
feat(swarms-macro): add macro for defining tools with attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["swarms-rs"]
+members = [ "swarms-macro","swarms-rs"]
 resolver = "3"

--- a/swarms-macro/Cargo.toml
+++ b/swarms-macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "swarms-macro"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1.0"
+syn = { version = "2.0", features = ["full"] }
+proc-macro2 = "1.0"

--- a/swarms-macro/src/lib.rs
+++ b/swarms-macro/src/lib.rs
@@ -1,0 +1,8 @@
+use proc_macro::TokenStream;
+
+mod tool;
+
+#[proc_macro_attribute]
+pub fn tool(attr: TokenStream, item: TokenStream) -> TokenStream {
+    tool::tool_impl(attr, item)
+}

--- a/swarms-macro/src/tool.rs
+++ b/swarms-macro/src/tool.rs
@@ -1,0 +1,421 @@
+//! Fork from https://docs.rs/crate/rig-tool-macro/0.5.0
+
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{ToTokens, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::{Error, Ident, LitStr, Meta, Result, Token};
+use syn::{FnArg, ItemFn, PatType, ReturnType, Type, parse_macro_input};
+
+#[derive(Debug, Default)]
+struct ToolAttribute {
+    name: Option<String>,
+    description: Option<String>,
+    args: Vec<ArgMeta>,
+}
+
+#[derive(Debug)]
+struct ArgMeta {
+    name: String,
+    description: Option<String>,
+}
+
+impl Parse for ToolAttribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attr = ToolAttribute::default();
+
+        let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+
+        for meta in metas {
+            match meta {
+                Meta::NameValue(nv) => {
+                    let ident = nv
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| Error::new_spanned(&nv.path, "Expected identifier"))?;
+
+                    let value = nv.value.clone();
+                    let lit_result = syn::parse2::<LitStr>(nv.value.into_token_stream());
+                    match (ident.to_string().as_str(), lit_result) {
+                        ("name", Ok(lit)) => attr.name = Some(lit.value()),
+                        ("description", Ok(lit)) => attr.description = Some(lit.value()),
+                        (_, Err(e)) => {
+                            return Err(Error::new_spanned(
+                                value,
+                                format!("Expected string literal, error: {e}"),
+                            ));
+                        }
+                        _ => {
+                            return Err(Error::new_spanned(
+                                ident,
+                                format!("Unknown attribute key: {}", ident),
+                            ));
+                        }
+                    }
+                }
+
+                Meta::List(list) if list.path.is_ident("arg") => {
+                    let args =
+                        list.parse_args_with(Punctuated::<ArgMeta, Token![,]>::parse_terminated)?;
+                    attr.args.append(&mut args.into_iter().collect());
+                }
+
+                meta => {
+                    return Err(Error::new_spanned(
+                        meta,
+                        "Unsupported attribute format, expected `key = value` or `arg(...)`",
+                    ));
+                }
+            }
+        }
+
+        Ok(attr)
+    }
+}
+
+impl Parse for ArgMeta {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut arg = ArgMeta {
+            name: input.parse::<Ident>()?.to_string().trim().to_owned(),
+            description: None,
+        };
+
+        if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+            let metas = Punctuated::<Meta, Token![,]>::parse_terminated(input)?;
+
+            for meta in metas {
+                match meta {
+                    Meta::NameValue(nv) => {
+                        let ident = nv
+                            .path
+                            .get_ident()
+                            .ok_or_else(|| Error::new_spanned(&nv.path, "Expected identifier"))?;
+
+                        let value = nv.value.clone();
+                        match ident.to_string().as_str() {
+                            "description" => {
+                                let lit = syn::parse2::<LitStr>(nv.value.into_token_stream())
+                                    .map_err(|e| {
+                                        Error::new_spanned(
+                                            value,
+                                            format!("Expected string literal for description, error: {}", e),
+                                        )
+                                    })?;
+                                arg.description = Some(lit.value());
+                            }
+                            _ => {
+                                return Err(Error::new_spanned(
+                                    ident,
+                                    format!("Unknown arg property: {}", ident),
+                                ));
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(Error::new_spanned(
+                            meta,
+                            "Expected `key = value` format for arg properties",
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(arg)
+    }
+}
+
+fn to_pascal_case(s: &str) -> String {
+    s.split('_')
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().chain(chars).collect(),
+            }
+        })
+        .collect()
+}
+
+fn get_json_type(ty: &Type) -> TokenStream2 {
+    match ty {
+        Type::Path(type_path) => {
+            let segment = &type_path.path.segments[0];
+            let type_name = segment.ident.to_string();
+
+            // Handle Vec types
+            if type_name == "Vec" {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let syn::GenericArgument::Type(inner_type) = &args.args[0] {
+                        let inner_json_type = get_json_type(inner_type);
+                        return quote! {
+                            "type": "array",
+                            "items": { #inner_json_type }
+                        };
+                    }
+                }
+                return quote! { "type": "array" };
+            }
+
+            // Handle primitive types
+            match type_name.as_str() {
+                "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" => {
+                    quote! { "type": "number" }
+                }
+                "String" | "str" => {
+                    quote! { "type": "string" }
+                }
+                "bool" => {
+                    quote! { "type": "boolean" }
+                }
+                // Handle other types as objects
+                _ => {
+                    quote! { "type": "object" }
+                }
+            }
+        }
+        _ => quote! { "type": "object" },
+    }
+}
+
+/// Check if the given type is a custom struct or Vec<Struct> (not a primitive or standard library type)
+fn is_custom_struct(ty: &Type) -> bool {
+    match ty {
+        Type::Path(type_path) => {
+            let segment = &type_path.path.segments[0];
+            let type_name = segment.ident.to_string();
+
+            // Check if it's a Vec<T>
+            if type_name == "Vec" {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let syn::GenericArgument::Type(inner_type) = &args.args[0] {
+                        return is_custom_struct(inner_type);
+                    }
+                }
+                return false;
+            }
+
+            // List of known primitive and standard library types
+            !matches!(
+                type_name.as_str(),
+                "i8" | "i16"
+                    | "i32"
+                    | "i64"
+                    | "isize"
+                    | "u8"
+                    | "u16"
+                    | "u32"
+                    | "u64"
+                    | "usize"
+                    | "f32"
+                    | "f64"
+                    | "bool"
+                    | "String"
+                    | "str"
+                    | "Vec"
+                    | "Option"
+                    | "Result"
+            )
+        }
+        _ => false,
+    }
+}
+
+pub fn tool_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let tool_attr = parse_macro_input!(attr as ToolAttribute);
+    let input_fn = parse_macro_input!(item as ItemFn);
+
+    let fn_name = &input_fn.sig.ident;
+    let tool_name = match tool_attr.name {
+        Some(name) => name,
+        None => input_fn.sig.ident.to_string(),
+    };
+
+    let struct_name = quote::format_ident!("{}Tool", to_pascal_case(&tool_name));
+    let static_name = quote::format_ident!("{}", to_pascal_case(&tool_name));
+
+    // Extract return type: Result<T, E>
+    let (return_type, error_type) = if let ReturnType::Type(_, ty) = &input_fn.sig.output {
+        if let Type::Path(type_path) = ty.as_ref() {
+            if type_path.path.segments[0].ident == "Result" {
+                match &type_path.path.segments[0].arguments {
+                    syn::PathArguments::AngleBracketed(args) => {
+                        let params: Vec<_> = args.args.iter().collect();
+
+                        if params.is_empty() || params.len() > 2 {
+                            panic!("Result must have 1 or 2 type parameters");
+                        }
+
+                        let t = match params[0] {
+                            syn::GenericArgument::Type(ty) => ty,
+                            _ => panic!("Result must have a type parameter"),
+                        };
+
+                        let e = if params.len() == 2 {
+                            match params[1] {
+                                syn::GenericArgument::Type(ty) => ty.clone(),
+                                _ => panic!("Result must have a type parameter"),
+                            }
+                        } else {
+                            panic!("Result must have a type parameter");
+                        };
+
+                        (t, e)
+                    }
+                    _ => panic!("Result must have type parameters"),
+                }
+            } else {
+                panic!("Function must return a Result<T, E> or Result<T>")
+            }
+        } else {
+            panic!("Expected angle bracketed arguments in Result")
+        }
+    } else {
+        panic!("Function must return a Result")
+    };
+
+    let args = input_fn.sig.inputs.iter().filter_map(|arg| {
+        if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+            Some((pat, ty))
+        } else {
+            None
+        }
+    });
+
+    let arg_names: Vec<_> = args.clone().map(|(pat, _)| pat).collect();
+    let arg_types: Vec<_> = args.clone().map(|(_, ty)| ty).collect();
+    let json_types: Vec<_> = arg_types.iter().map(|ty| get_json_type(ty)).collect();
+
+    let is_struct_args = arg_types.iter().any(|ty| is_custom_struct(ty));
+
+    // if arg is struct,  it should be the only arg
+    if is_struct_args && arg_types.len() != 1 {
+        panic!("Struct args must be the only arg");
+    }
+
+    // arg attributes must be one of the function arguments
+    for arg in &tool_attr.args {
+        if !arg_names.iter().any(|pat| {
+            if let syn::Pat::Ident(pat_ident) = &***pat {
+                pat_ident.ident == arg.name
+            } else {
+                false
+            }
+        }) {
+            panic!("Argument {} not found in function arguments", arg.name);
+        }
+    }
+
+    // arg attributes must have a description
+    for arg in &tool_attr.args {
+        if arg.description.is_none() {
+            panic!("Argument {} must have a description", arg.name);
+        }
+    }
+
+    // an arg can not appear more than once, otherwise will panic
+    let mut arg_names_set = std::collections::HashSet::new();
+    for arg in &tool_attr.args {
+        if arg_names_set.contains(&arg.name) {
+            panic!("Argument {} appears more than once", arg.name);
+        }
+        arg_names_set.insert(arg.name.clone());
+    }
+
+    let arg_descriptions: Vec<_> = arg_names
+        .iter()
+        .map(|pat| {
+            let ident = match &***pat {
+                syn::Pat::Ident(pat_ident) => &pat_ident.ident,
+                _ => panic!("Only simple identifiers are supported in tool arguments"),
+            };
+            let arg_meta = tool_attr.args.iter().find(|arg| *ident == arg.name);
+            arg_meta
+                .and_then(|arg| arg.description.clone())
+                .unwrap_or_else(|| format!("Parameter {}", ident))
+        })
+        .collect();
+
+    let args_struct_name = quote::format_ident!("{}Args", to_pascal_case(&tool_name));
+
+    let call_impl = if input_fn.sig.asyncness.is_some() {
+        quote! {
+            async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+                #fn_name(#(args.#arg_names),*).await
+            }
+        }
+    } else {
+        quote! {
+            async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+                #fn_name(#(args.#arg_names),*)
+            }
+        }
+    };
+    // Modify the definition implementation to use the description
+    let description = match tool_attr.description {
+        Some(desc) => quote! { #desc.to_string() },
+        None => quote! { format!("Function to {}", Self::NAME) },
+    };
+
+    let definition_impl = if !is_struct_args {
+        quote! {
+            fn definition(&self) -> swarms_rs::llm::request::ToolDefinition {
+                swarms_rs::llm::request::ToolDefinition {
+                    name: Self::NAME.to_string(),
+                    description: #description,
+                    parameters: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            #(
+                                stringify!(#arg_names): {
+                                    #json_types,
+                                    "description": #arg_descriptions
+                                }
+                            ),*
+                        },
+                    }),
+                }
+            }
+        }
+    } else {
+        quote! {
+            fn definition(&self) -> swarms_rs::llm::request::ToolDefinition {
+                swarms_rs::llm::request::ToolDefinition {
+                    name: Self::NAME.to_string(),
+                    description: #description,
+                    parameters: schemars::schema_for!(#args_struct_name).as_value().to_owned(),
+                }
+            }
+        }
+    };
+
+    let expanded = quote! {
+        #[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize)]
+        pub struct #struct_name;
+
+        #[derive(Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+        pub struct #args_struct_name {
+            #(#arg_names: #arg_types),*
+        }
+
+        #input_fn
+
+        impl swarms_rs::structs::tool::Tool for #struct_name {
+            const NAME: &'static str = #tool_name;
+
+            type Error = #error_type;
+            type Args = #args_struct_name;
+            type Output = #return_type;
+
+            #definition_impl
+
+            #call_impl
+        }
+
+        pub static #static_name: #struct_name = #struct_name;
+    };
+
+    expanded.into()
+}

--- a/swarms-rs/Cargo.toml
+++ b/swarms-rs/Cargo.toml
@@ -15,6 +15,7 @@ keywords = ["ai", "agents", "swarms", "multi-agent", "llm"]
 # Standard utilities
 chrono = { version = "0.4", features = ["serde"] }
 dashmap = { version = "6", features = ["serde"] }
+schemars = "=1.0.0-alpha.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 erased-serde = "0.4"
@@ -52,6 +53,9 @@ rmcp = { version = "0.1.5", features = [
     "transport-sse",
     "transport-child-process",
 ] }
+
+# macro
+swarms-macro = { path = "../swarms-macro" }
 
 [dev-dependencies]
 anyhow = "1"

--- a/swarms-rs/examples/tool.rs
+++ b/swarms-rs/examples/tool.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         .agent_builder()
         .system_prompt("You need to select the right tool to answer the question.")
         .agent_name("SwarmsAgent")
-        .user_name("M4n5ter")
+        .user_name("Swarms User")
         .enable_autosave()
         .max_loops(1)
         .save_state_dir("./temp")
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
         .unwrap();
     println!("{result}");
     // The output might be:
-    // "{\"don_t_tell_you_what_it_means_1\":[\"docker run --network host -e POSTGRES_PASSWORD=mysecretpassword -d postgres:alpine\",\"cat /etc/os-release\",\"curl ifconfig.me\"],\"don_t_tell_you_what_it_means_2\":true,\"don_t_tell_you_what_it_means_3\":\"M4n5ter\"}"
+    // "{\"don_t_tell_you_what_it_means_1\":[\"docker run --network host -e POSTGRES_PASSWORD=mysecretpassword -d postgres:alpine\",\"cat /etc/os-release\",\"curl ifconfig.me\"],\"don_t_tell_you_what_it_means_2\":true,\"don_t_tell_you_what_it_means_3\":\"Swarms User\"}"
 
     Ok(())
 }

--- a/swarms-rs/examples/tool.rs
+++ b/swarms-rs/examples/tool.rs
@@ -1,0 +1,149 @@
+use std::env;
+
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use swarms_macro::tool;
+use swarms_rs::llm::provider::openai::OpenAI;
+use swarms_rs::structs::agent::Agent;
+use thiserror::Error;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+
+    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_line_number(true)
+        .with_file(true)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let base_url = env::var("DEEPSEEK_BASE_URL").unwrap();
+    let api_key = env::var("DEEPSEEK_API_KEY").unwrap();
+    let client = OpenAI::from_url(base_url, api_key).set_model("deepseek-chat");
+    let agent = client
+        .agent_builder()
+        .system_prompt("You need to select the right tool to answer the question.")
+        .agent_name("SwarmsAgent")
+        .user_name("M4n5ter")
+        .enable_autosave()
+        .max_loops(1)
+        .save_state_dir("./temp")
+        .add_tool(SubTool)
+        .add_tool(Add) // or AddTool, Add is a pub static variable of AddTool
+        .add_tool(MultiplyTool)
+        .add_tool(Exec) // or ExecTool, Exec is a pub static variable of ExecTool
+        .build();
+
+    let mut result = agent.run("10 - 5".into()).await.unwrap();
+    println!("{result}");
+    // The output will be:
+    // 5.0
+
+    result = agent.run(format!("{} + 5", result)).await.unwrap();
+    println!("{result}");
+    // The output will be:
+    // 10.0
+
+    result = agent.run(format!("{} * 5", result)).await.unwrap();
+    println!("{result}");
+    // The output will be:
+    // 50.0
+
+    result = agent
+        .run("
+        Use docker to run a postgres database(newest version, alpine as base), set the network mode to host.
+        Then get current system's release.
+        Finally, curl something to get the IP address of current machine.
+        ".to_string()
+    )
+        .await
+        .unwrap();
+    println!("{result}");
+    // The output might be:
+    // "{\"don_t_tell_you_what_it_means_1\":[\"docker run --network host -e POSTGRES_PASSWORD=mysecretpassword -d postgres:alpine\",\"cat /etc/os-release\",\"curl ifconfig.me\"],\"don_t_tell_you_what_it_means_2\":true,\"don_t_tell_you_what_it_means_3\":\"M4n5ter\"}"
+
+    Ok(())
+}
+
+/// The return type of a tool must be `Result<T, E>`, where `T` is the type of the return value and `E` is the type of the error.
+///
+/// T must implement `serde::Serialize` trait.
+///
+/// E must implement `core::error::Error` trait, maybe `thiserror::Error` is a good choice.
+#[tool(
+    description = "Subtract y from x (i.e.: x - y)",
+    arg(x, description = "The number to subtract from"),
+    arg(y, description = "The number to subtract")
+)]
+fn sub(x: f64, y: f64) -> Result<f64, CalcError> {
+    tracing::info!("Sub tool is called");
+    Ok(x - y)
+}
+
+#[tool]
+fn add(x: f64, y: f64) -> Result<f64, CalcError> {
+    tracing::info!("Add tool is called");
+    Ok(x + y)
+}
+
+#[tool(name = "Multiply", description = "Multiply x and y (i.e.: x * y)")]
+fn mul(x: f64, y: f64) -> Result<f64, CalcError> {
+    tracing::info!("Mul tool is called");
+    Ok(x * y)
+}
+
+/// This shows how to use a struct as parameter.
+/// We can describe the field of the struct, just see the `ExecShell` struct.
+#[tool(description = "
+Execute the shell command, can execute multiple commands at once.
+")]
+fn exec(x: ExecShell) -> Result<String, CalcError> {
+    tracing::info!("exec tool is called");
+    let results = serde_json::to_string(&x).unwrap();
+
+    Ok(results)
+}
+
+/// The request to execute the shell command.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct ExecShell {
+    #[doc = "The commands to execute, can execute multiple commands at once."]
+    don_t_tell_you_what_it_means_1: Vec<String>,
+    /// The flag to execute the command
+    don_t_tell_you_what_it_means_2: bool,
+    /// Who wants to execute the command
+    don_t_tell_you_what_it_means_3: String,
+}
+
+/// ## IMPORTANT
+///
+/// You can use a struct as parameter too, but only one parameter is allowed.
+///
+/// The struct must implement `serde::Serialize` and `serde::Deserialize` traits.
+///
+/// The struct must also implement `schemars::JsonSchema` trait. `schemars` must newer than 1.0.0.
+///
+/// Both #[doc = "..."] and `///` comments are supported, the contents of both will be a description of the parameter.
+/// If #[doc] or `///` is above the struct, it will be the description of the struct.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct ExampleStructParameterToHaveADescription {
+    #[doc = "The first field"]
+    first_field: String,
+    /// The second field
+    second_field: String,
+    /// The third field
+    third_field: Vec<ThirdField>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct ThirdField {
+    /// The first field
+    first_field: String,
+    /// The second field
+    second_field: String,
+}
+
+#[derive(Debug, Error)]
+pub enum CalcError {}


### PR DESCRIPTION
Introduce a new macro `swarms-macro` to simplify the creation of tools with attributes like name, description, and argument metadata. The macro generates the necessary structs and implementations for tool definitions, reducing boilerplate code and improving maintainability. This change also includes updates to `Cargo.toml` to integrate the new macro and an example demonstrating its usage.