### PR TITLE
Add workspace examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = [ "swarms-macro","swarms-rs"]
+members = ["swarms-macro", "swarms-rs", "examples/*"]
 resolver = "3"

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,8 @@ This folder contains numerous examples showing how to use swarms-rs. Each exampl
 
 ## Running an example
 
+At the root of the project:
+
 ```shell
-cd examples/binance-swarms-agent
-cargo run
+cargo run --package binance-swarms-agent
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Examples
+
+This folder contains numerous examples showing how to use swarms-rs. Each example is setup as its own crate so its dependencies are clear.
+
+## Running an example
+
+```shell
+cd examples/binance-swarms-agent
+cargo run
+```

--- a/examples/binance-swarms-agent/.env.example
+++ b/examples/binance-swarms-agent/.env.example
@@ -1,0 +1,4 @@
+RUST_LOG=debug
+
+DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxx

--- a/examples/binance-swarms-agent/Cargo.toml
+++ b/examples/binance-swarms-agent/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "binance-swarms-agent"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+anyhow = "1"
+dotenv = "0.15"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+swarms-rs = { path = "../../swarms-rs" }

--- a/examples/binance-swarms-agent/README.md
+++ b/examples/binance-swarms-agent/README.md
@@ -1,0 +1,165 @@
+# Binance Swarms Agent
+
+This is an example agent built using the `swarms-rs` framework, designed to interact with the Binance API for cryptocurrency trading strategy analysis.
+
+## Overview
+
+This agent acts as a Crypto Trading Strategist. Users can provide their current holdings (e.g., BTC and ETH) and ask it to evaluate short-term market trends for trading opportunities. The agent utilizes the Binance API to fetch real-time market data and provides analysis based on the user's request.
+
+## Key Features
+
+- **Market Structure Analysis**: Identifies key support and resistance levels based on recent price action.
+- **Order Book Liquidity Analysis**: Analyzes the current order book liquidity distribution to assess the strength of support/resistance levels.
+- **Sentiment & Capital Flow Analysis**: Shows volume patterns over 24 hours, looking for signs of institutional accumulation or distribution.
+- **Bid-Ask Spread & Market Depth**: Evaluates the current bid-ask spread tightness and market depth to judge the risk of trend continuation.
+- **Actionable Strategy Recommendations**: Based on the combined analysis, suggests whether to buy dips or wait for breakout confirmation.
+- **Risk Management**: Defines specific stop-loss and take-profit targets based on user-defined risk tolerance (e.g., max 10% drawdown per trade).
+
+## Installation & Setup
+
+1.  **Environment Configuration**:
+    - Copy the example environment file: `cp .env.example .env`
+    - Edit the `.env` file and fill in your Binance API key and secret.
+      ```dotenv
+      DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+      DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxxx
+      ```
+
+## How to Run
+
+In the root directory, run the following command:
+
+```bash
+cargo run --package binance-swarms-agent
+```
+
+Once the program starts, it will simulate an interaction between a user and the Crypto Trading Strategist agent, outputting the analysis results as shown in the example.
+
+## Example Output
+
+```text
+User(User): Timestamp(millis): 1744954034436 
+
+            I currently hold BTC and ETH and want to evaluate short-term market trends for trading opportunities. Please provide analysis covering:
+
+            Market Structure
+            What are the key support/resistance levels based on recent price action?
+            How does current order book liquidity distribution reinforce these levels?
+            Sentiment & Capital Flows
+            Show me volume patterns over 24hrs - any signs of institutional accumulation/distribution?
+            How tight are bid-ask spreads currently? Does market depth suggest trend continuation risks?
+            Actionable Strategy
+            Based on confluence: Would you favor buying dips or waiting for breakout confirmation in the next 48hrs?
+            Define specific alert levels: Where would you set stop-loss and take-profit targets?
+            Risk parameters: Medium tolerance (max 10% drawdown per trade).
+        
+Crypto Trading Strategist(Assistant): Timestamp(millis): 1744954068977 
+[Tool name]: klines
+[Tool args]: {"interval":"1h","limit":24,"symbol":"BTCUSDT"}
+[Tool result]: "[[...Kline data...]]"
+
+[Tool name]: klines
+[Tool args]: {"interval":"1h","limit":24,"symbol":"ETHUSDT"}
+[Tool result]: "[[...Kline data...]]"
+
+[Tool name]: depth
+[Tool args]: {"limit":10,"symbol":"BTCUSDT"}
+[Tool result]: "{...Depth data...}"
+
+[Tool name]: depth
+[Tool args]: {"limit":10,"symbol":"ETHUSDT"}
+[Tool result]: "{...Depth data...}"
+
+[Tool name]: ticker_24hr
+[Tool args]: {"symbol":"BTCUSDT"}
+[Tool result]: "{...24hr Ticker data...}"
+
+[Tool name]: ticker_24hr
+[Tool args]: {"symbol":"ETHUSDT"}
+[Tool result]: "{...24hr Ticker data...}"
+
+
+Crypto Trading Strategist(Assistant): Timestamp(millis): 1744954109497 
+### **Market Structure Analysis**
+
+#### **Key Support/Resistance Levels**
+- **BTC/USDT**:
+  - **Support Levels**: 
+    - Immediate: $84,630 (current bid price, reinforced by order book liquidity).
+    - Stronger: $84,000 (recent swing low).
+  - **Resistance Levels**: 
+    - Immediate: $85,140 (recent high).
+    - Stronger: $85,470 (24hr high).
+  
+- **ETH/USDT**:
+  - **Support Levels**: 
+    - Immediate: $1,575.74 (current bid price).
+    - Stronger: $1,563 (24hr low).
+  - **Resistance Levels**: 
+    - Immediate: $1,585 (recent consolidation zone).
+    - Stronger: $1,616 (24hr high).
+
+#### **Order Book Liquidity**
+- **BTC/USDT**:
+  - Bids are concentrated around $84,630, with significant liquidity (~5.71 BTC). Asks are thin above $84,630, suggesting resistance is weak if buying pressure increases.
+- **ETH/USDT**:
+  - Bids are stacked at $1,575.74 (~36 ETH), while asks are dense at $1,575.75 (~38 ETH), indicating a tight range. Break above $1,585 could trigger momentum.
+
+---
+
+### **Sentiment & Capital Flows**
+
+#### **Volume Patterns (24hr)**
+- **BTC/USDT**:
+  - Volume spiked during the dip to $83,736 (accumulation signal) and again near $85,470 (distribution). Current volume is moderate, suggesting consolidation.
+- **ETH/USDT**:
+  - Large volume spike at $1,563 (accumulation) and $1,616 (distribution). Recent volume is declining, indicating indecision.
+
+#### **Bid-Ask Spread & Market Depth**
+- **BTC/USDT**: 
+  - Spread: Tight ($84,630 bid vs. $84,630.84 ask).
+  - Depth: Thin asks above current price, favoring upside if demand returns.
+- **ETH/USDT**: 
+  - Spread: Very tight ($1,575.74 bid vs. $1,575.75 ask).
+  - Depth: Balanced, but resistance at $1,585 is strong.
+
+---
+
+### **Actionable Strategy**
+
+#### **BTC/USDT**
+- **Scenario 1 (Buy Dips)**:
+  - Entry: $84,000–$84,500 (support zone).
+  - Stop-Loss: $83,600 (below recent low, ~5% risk).
+  - Take-Profit: $85,470 (resistance) or $86,000 (next psychological level).
+- **Scenario 2 (Breakout Confirmation)**:
+  - Entry: Above $85,470 with volume.
+  - Stop-Loss: $84,900 (below breakout level).
+  - Take-Profit: $87,000 (next resistance).
+
+#### **ETH/USDT**
+- **Scenario 1 (Buy Dips)**:
+  - Entry: $1,575–$1,580 (support).
+  - Stop-Loss: $1,550 (~2% risk).
+  - Take-Profit: $1,610–$1,616 (resistance).
+- **Scenario 2 (Breakout Confirmation)**:
+  - Entry: Above $1,585 with volume.
+  - Stop-Loss: $1,570.
+  - Take-Profit: $1,630.
+
+#### **Risk Parameters**
+- Max drawdown per trade: 10% (aligned with your tolerance).
+- Position sizing: Adjust to ensure stop-loss levels stay within risk limits.
+
+---
+
+### **Final Recommendation**
+- **BTC**: Favor buying dips near $84,000–$84,500, given strong support and thin resistance. Monitor for breakout above $85,470.
+- **ETH**: Wait for breakout above $1,585 or dip to $1,575 for lower-risk entry.
+
+Let me know if you'd like further refinement or real-time alerts!
+Crypto Trading Strategist(Assistant): Timestamp(millis): 1744954114389 
+[Tool name]: task_evaluator
+[Tool args]: {"status":{"is_complete":true}}
+[Tool result]: {"is_complete":true,"context":null}
+```

--- a/examples/binance-swarms-agent/src/main.rs
+++ b/examples/binance-swarms-agent/src/main.rs
@@ -1,0 +1,58 @@
+use std::env;
+
+use anyhow::Result;
+use swarms_rs::{llm::provider::openai::OpenAI, structs::agent::Agent};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_line_number(true)
+                .with_file(true),
+        )
+        .init();
+
+    let base_url = env::var("DEEPSEEK_BASE_URL").unwrap();
+    let api_key = env::var("DEEPSEEK_API_KEY").unwrap();
+    let client = OpenAI::from_url(base_url, api_key).set_model("deepseek-chat");
+    let agent = client
+        .agent_builder()
+        .system_prompt("
+            You are a Crypto Trading Strategist, an expert in digital asset markets with deep expertise in technical analysis (TA), on-chain analytics, and macroeconomic factors.
+            Your role is to provide data-driven insights, trading strategies, and risk-aware guidance")
+        .agent_name("Crypto Trading Strategist")
+        .user_name("User")
+        .add_stdio_mcp_server("cargo", ["run", "--package", "binance-tools"])
+        .await
+        // .add_sse_mcp_server("binance api", "http://127.0.0.1:8000/sse").await
+        .retry_attempts(3)
+        .max_loops(300) // max loops for the agent
+        .enable_autosave()
+        .save_state_dir("./temp/binance-swarms-agent")
+        .build();
+
+    let response = agent
+        .run("
+            I currently hold BTC and ETH and want to evaluate short-term market trends for trading opportunities. Please provide analysis covering:
+
+            Market Structure
+            What are the key support/resistance levels based on recent price action?
+            How does current order book liquidity distribution reinforce these levels?
+            Sentiment & Capital Flows
+            Show me volume patterns over 24hrs - any signs of institutional accumulation/distribution?
+            How tight are bid-ask spreads currently? Does market depth suggest trend continuation risks?
+            Actionable Strategy
+            Based on confluence: Would you favor buying dips or waiting for breakout confirmation in the next 48hrs?
+            Define specific alert levels: Where would you set stop-loss and take-profit targets?
+            Risk parameters: Medium tolerance (max 10% drawdown per trade).
+        ".to_owned())
+        .await
+        .unwrap();
+
+    println!("{response}");
+    Ok(())
+}

--- a/examples/binance-tools/Cargo.toml
+++ b/examples/binance-tools/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "binance-tools"
+version = "0.1.0"
+edition = "2024"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1"
+chrono = "0.4"
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+    "server",
+    "macros",
+    "transport-io",
+    "transport-sse-server",
+] }
+tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+schemars = { version = "0.8", features = ["derive"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+validator = { version = "0.20", features = ["derive"] }
+
+
+# auth
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+
+# http client
+reqwest = { version = "0.12", features = ["json"] }

--- a/examples/binance-tools/README.md
+++ b/examples/binance-tools/README.md
@@ -1,0 +1,24 @@
+# Binance tools
+
+- [x] Market Data endpoints
+- [ ] Trading endpoints
+- [ ] Account endpoints
+
+## Environment Variables
+
+- `BINANCE_MCP_SSE_ADDR` - Binance MCP SSE address, default: `127.0.0.1:8000`
+
+## Usage
+
+```shell
+cargo run --package binance-tools --release
+```
+
+Or (debug mode)
+```shell
+cargo run --package binance-tools
+```
+
+Both STDIO and SSE MCP server enabled.
+
+SSE MCP server: `http://BINANCE_MCP_SSE_ADDR/sse`

--- a/examples/binance-tools/src/api/market_data/README.md
+++ b/examples/binance-tools/src/api/market_data/README.md
@@ -1,0 +1,3 @@
+# Binance Market Data endpoints
+
+[Reference](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/market-data-endpoints)

--- a/examples/binance-tools/src/api/market_data/agg_trades.rs
+++ b/examples/binance-tools/src/api/market_data/agg_trades.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+const API_URL: &str = "/api/v3/aggTrades";
+
+/// Get compressed, aggregate trades. Trades that fill at the time, from the same taker order, with the same price will have the quantity aggregated.
+pub async fn agg_trades(
+    client: &Client,
+    base_url: &str,
+    mut params: AggTradesRequest,
+) -> Result<Vec<AggTradesResponse>> {
+    params.validate()?;
+    if params.limit.is_none() {
+        params.limit = Some(500);
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// The difference from trades is that the transactions of the same taker with multiple makers at the same time and the same price will be combined into one record.
+///
+/// If no filter parameters (fromId, startTime, endTime) are sent, the most recent transaction records will be returned by default.
+pub struct AggTradesRequest {
+    pub symbol: String,
+    /// From which transaction ID to start returning. If not specified, the most recent transaction records will be returned by default.
+    pub from_id: Option<i64>,
+    /// Unix timestamp in milliseconds. Return the results starting from the transaction records after that moment
+    pub start_time: Option<i64>,
+    /// Unix timestamp in milliseconds. Return the results ending at the transaction records before that moment
+    pub end_time: Option<i64>,
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AggTradesResponse {
+    /// Aggregate trade ID
+    pub a: i64,
+    /// Price
+    pub p: String,
+    /// Quantity
+    pub q: String,
+    /// First trade ID
+    pub f: i64,
+    /// Last trade ID
+    pub l: i64,
+
+    #[serde(rename = "T")]
+    /// Unix timestamp in milliseconds. 
+    pub T: i64,
+    /// Is the buyer the market maker?
+    pub m: bool,
+    #[serde(rename = "M")]
+    /// Was the trade the best price match? (can be ignored, always true)
+    pub M: bool,
+}

--- a/examples/binance-tools/src/api/market_data/avg_price.rs
+++ b/examples/binance-tools/src/api/market_data/avg_price.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "/api/v3/avgPrice";
+
+/// Current average price for a symbol.
+pub async fn avg_price(
+    client: &Client,
+    base_url: &str,
+    params: AvgPriceRequest,
+) -> Result<AvgPriceResponse> {
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// Request current average price for a symbol.
+pub struct AvgPriceRequest {
+    pub symbol: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AvgPriceResponse {
+    /// Average price interval (in minutes)
+    pub mins: u64,
+    /// Average price
+    pub price: String,
+    /// Last trade time. Unix timestamp in milliseconds.
+    pub close_time: u64,
+}

--- a/examples/binance-tools/src/api/market_data/depth.rs
+++ b/examples/binance-tools/src/api/market_data/depth.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+const API_URL: &str = "/api/v3/depth";
+
+/// Depth information.
+pub async fn depth(
+    client: &Client,
+    base_url: &str,
+    mut params: DepthRequest,
+) -> Result<DepthResponse> {
+    params.validate()?;
+
+    if params.limit.is_none() {
+        params.limit = Some(100);
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    let response = response.json::<DepthResponse>().await?;
+    Ok(response)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+pub struct DepthRequest {
+    pub symbol: String,
+    #[validate(range(min = 1, max = 5000))]
+    pub limit: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// Depth information.
+/// # Example
+/// ```
+/// {
+///   "lastUpdateId": 1027024,
+///   "bids": [
+///     [
+///       "4.00000000",     // PRICE
+///       "431.00000000"    // QTY
+///     ]
+///   ],
+///   "asks": [
+///     [
+///       "4.00000200",
+///       "12.00000000"
+///     ]
+///   ]
+/// }
+/// ```
+pub struct DepthResponse {
+    pub last_update_id: i64,
+    pub bids: Vec<[String; 2]>,
+    pub asks: Vec<[String; 2]>,
+}

--- a/examples/binance-tools/src/api/market_data/historical_trades.rs
+++ b/examples/binance-tools/src/api/market_data/historical_trades.rs
@@ -1,0 +1,47 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+const API_URL: &str = "/api/v3/historicalTrades";
+
+/// Get older trades.
+pub async fn historical_trades(
+    client: &Client,
+    base_url: &str,
+    mut params: HistoricalTradesRequest,
+) -> Result<HistoricalTradesResponse> {
+    params.validate()?;
+    if params.limit.is_none() {
+        params.limit = Some(500);
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoricalTradesRequest {
+    pub symbol: String,
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<i32>,
+    /// From which transaction ID to start returning. If not specified, the most recent transaction records will be returned by default.
+    pub from_id: Option<i64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoricalTradesResponse {
+    pub id: i64,
+    pub price: String,
+    pub qty: String,
+    /// Unix timestamp in milliseconds.
+    pub time: i64,
+    pub is_buyer_maker: bool,
+    pub is_best_match: bool,
+}

--- a/examples/binance-tools/src/api/market_data/klines.rs
+++ b/examples/binance-tools/src/api/market_data/klines.rs
@@ -1,0 +1,132 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+const API_URL: &str = "/api/v3/klines";
+
+/// Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+pub async fn klines(
+    client: &Client,
+    base_url: &str,
+    mut params: KlinesRequest,
+) -> Result<Vec<KlinesResponse>> {
+    params.validate()?;
+    if params.limit.is_none() {
+        params.limit = Some(500);
+    }
+
+    if params.time_zone.is_none() {
+        params.time_zone = Some("0".to_owned());
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// The opening time of each K-line can be regarded as a unique ID.
+///
+/// Notes:
+/// - If `startTime` and `endTime` are not sent, the most recent klines are returned.
+/// - Supported values for `timeZone`:
+///   - Hours and minutes (e.g. `-1:00`, `05:45`)
+///   - Only hours (e.g. `0`, `8`, `4`)
+///   - Accepted range is strictly [-12:00 to +14:00] inclusive
+/// - If `timeZone` provided, kline intervals are interpreted in that `timezone` instead of UTC.
+/// - Note that `startTime` and `endTime` are always interpreted in UTC, regardless of `timeZone`.
+pub struct KlinesRequest {
+    pub symbol: String,
+    /// K-line interval
+    pub interval: KLineInterval,
+    /// Unix timestamp in milliseconds.
+    pub start_time: Option<i64>,
+    /// Unix timestamp in milliseconds.
+    pub end_time: Option<i64>,
+    /// time zone, default: 0(UTC)
+    pub time_zone: Option<String>,
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub enum KLineInterval {
+    #[serde(rename = "1s")]
+    OneSecond,
+    #[serde(rename = "1m")]
+    OneMinute,
+    #[serde(rename = "3m")]
+    ThreeMinutes,
+    #[serde(rename = "5m")]
+    FiveMinutes,
+    #[serde(rename = "15m")]
+    FifteenMinutes,
+    #[serde(rename = "30m")]
+    ThirtyMinutes,
+    #[serde(rename = "1h")]
+    OneHour,
+    #[serde(rename = "2h")]
+    TwoHours,
+    #[serde(rename = "4h")]
+    FourHours,
+    #[serde(rename = "6h")]
+    SixHours,
+    #[serde(rename = "8h")]
+    EightHours,
+    #[serde(rename = "12h")]
+    TwelveHours,
+    #[serde(rename = "1d")]
+    OneDay,
+    #[serde(rename = "3d")]
+    ThreeDays,
+    #[serde(rename = "1w")]
+    OneWeek,
+    #[serde(rename = "1M")]
+    OneMonth,
+}
+
+/// 0: Kline open time. Unix timestamp in milliseconds.
+/// 1: Open price
+/// 2: High price
+/// 3: Low price
+/// 4: Close price
+/// 5: Volume
+/// 6: Kline Close time. Unix timestamp in milliseconds.
+/// 7: Quote asset volume
+/// 8: Number of trades
+/// 9: Taker buy base asset volume
+/// 10: Taker buy quote asset volume
+/// 11: Unused field, ignore.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct KlinesResponse(
+    /// 0: Kline open time. Unix timestamp in milliseconds.
+    pub i64,
+    /// 1: Open price
+    pub String,
+    /// 2: High price
+    pub String,
+    /// 3: Low price
+    pub String,
+    /// 4: Close price
+    pub String,
+    /// 5: Volume
+    pub String,
+    /// 6: Kline Close time. Unix timestamp in milliseconds.
+    pub i64,
+    /// 7: Quote asset volume
+    pub String,
+    /// 8: Number of trades
+    pub i32,
+    /// 9: Taker buy base asset volume
+    pub String,
+    /// 10: Taker buy quote asset volume
+    pub String,
+    /// 11: Unused field, ignore.
+    pub String,
+);

--- a/examples/binance-tools/src/api/market_data/mod.rs
+++ b/examples/binance-tools/src/api/market_data/mod.rs
@@ -1,0 +1,27 @@
+#![allow(non_snake_case)]
+
+pub mod agg_trades;
+pub mod avg_price;
+pub mod depth;
+pub mod historical_trades;
+pub mod klines;
+pub mod ticker_24hr;
+pub mod ticker_book_ticker;
+pub mod ticker_price;
+pub mod ticker_rolling_window_price;
+pub mod ticker_trading_day;
+pub mod trades;
+pub mod ui_klines;
+
+pub use agg_trades::agg_trades;
+pub use avg_price::avg_price;
+pub use depth::depth;
+pub use historical_trades::historical_trades;
+pub use klines::klines;
+pub use ticker_24hr::ticker_24hr;
+pub use ticker_book_ticker::ticker_book_ticker;
+pub use ticker_price::ticker_price;
+pub use ticker_rolling_window_price::ticker_rolling_window_price;
+pub use ticker_trading_day::ticker_trading_day;
+pub use trades::trades;
+pub use ui_klines::ui_klines;

--- a/examples/binance-tools/src/api/market_data/ticker_24hr.rs
+++ b/examples/binance-tools/src/api/market_data/ticker_24hr.rs
@@ -1,0 +1,111 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "/api/v3/ticker/24hr";
+
+/// 24 hour rolling window price change statistics. Careful when accessing this with no symbol.
+pub async fn ticker_24hr(
+    client: &Client,
+    base_url: &str,
+    mut params: Ticker24HrRequest,
+) -> Result<Ticker24HrResponse> {
+    if params.r#type.is_none() {
+        params.r#type = Some(Ticker24HrType::Full);
+    }
+
+    if params.symbol.is_none() && params.symbols.is_none() {
+        bail!("Either symbol or symbols must be provided")
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// Please note that if the symbol parameter is not carried, data of all trading pairs will be returned. The data is not only huge, but also has a very high weight.
+pub struct Ticker24HrRequest {
+    /// Parameter symbol and symbols cannot be used in combination.
+    /// If neither parameter is sent, tickers for all symbols will be returned in an array.
+    ///
+    /// | Symbols Provided | Weight |
+    /// | --- | --- |
+    /// | 1 | 2 |
+    /// | symbol parameter is omitted | 80 |
+    pub symbol: Option<String>,
+    /// Examples of accepted format for the symbols parameter: ["BTCUSDT","BNBUSDT"]
+    /// or
+    /// %5B%22BTCUSDT%22,%22BNBUSDT%22%5D
+    ///
+    /// | Symbols Provided | Weight |
+    /// | --- | --- |
+    /// | 1-20 | 2 |
+    /// | 21-100 | 40 |
+    /// | 101 or more | 80 |
+    /// | symbols parameter is omitted | 80 |
+    pub symbols: Option<Vec<String>>,
+    /// Supported values: FULL or MINI.
+    /// If none provided, the default is FULL
+    pub r#type: Option<Ticker24HrType>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum Ticker24HrType {
+    Full,
+    Mini,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+/// If symbol is provided, the response is a single object.
+/// If symbols is provided, the response is an array of objects.
+pub enum Ticker24HrResponse {
+    Single(Box<Ticker24HrData>),
+    List(Vec<Ticker24HrData>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Ticker24HrData {
+    /// Symbol Name
+    pub symbol: String,
+    // --- Fields present in FULL only (marked as Option) ---
+    pub price_change: Option<String>,
+    pub price_change_percent: Option<String>,
+    pub weighted_avg_price: Option<String>,
+    pub prev_close_price: Option<String>,
+    pub last_qty: Option<String>,
+    pub bid_price: Option<String>,
+    pub bid_qty: Option<String>,
+    pub ask_price: Option<String>,
+    pub ask_qty: Option<String>,
+    // --- Fields present in both FULL and MINI ---
+    /// Closing price of the interval
+    pub last_price: String,
+    /// Opening price of the Interval
+    pub open_price: String,
+    /// Highest price in the interval
+    pub high_price: String,
+    /// Lowest price in the interval
+    pub low_price: String,
+    /// Total trade volume (in base asset)
+    pub volume: String,
+    /// Total trade volume (in quote asset)
+    pub quote_volume: String,
+    /// Start of the ticker interval. Unix timestamp in milliseconds.
+    pub open_time: i64,
+    /// End of the ticker interval. Unix timestamp in milliseconds.
+    pub close_time: i64,
+    /// First tradeId considered
+    pub first_id: i64,
+    /// Last tradeId considered
+    pub last_id: i64,
+    /// Total trade count
+    pub count: i64,
+}

--- a/examples/binance-tools/src/api/market_data/ticker_book_ticker.rs
+++ b/examples/binance-tools/src/api/market_data/ticker_book_ticker.rs
@@ -1,0 +1,63 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "/api/v3/ticker/bookTicker";
+
+/// Best price/qty on the order book for a symbol or symbols.
+pub async fn ticker_book_ticker(
+    client: &Client,
+    base_url: &str,
+    params: TickerBookTickerRequest,
+) -> Result<TickerBookTickerResponse> {
+    if params.symbol.is_none() && params.symbols.is_none() {
+        bail!("Either symbol or symbols must be provided")
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// Request best price/qty on the order book for a symbol or symbols.
+///
+/// **Weight**:
+///
+/// | Parameter | Symbols Provided | Weight |
+/// |-----------|------------------|--------|
+/// | symbol    | 1                | 2      |
+/// |     | symbol parameter is omitted | 4 |
+/// | symbols   | Any              | 4      |
+pub struct TickerBookTickerRequest {
+    /// Parameter symbol and symbols cannot be used in combination.
+    /// If neither parameter is sent, bookTickers for all symbols will be returned in an array.
+    pub symbol: Option<String>,
+    /// Examples of accepted format for the symbols parameter: ["BTCUSDT","BNBUSDT"]
+    /// or
+    /// %5B%22BTCUSDT%22,%22BNBUSDT%22%5D
+    pub symbols: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+/// If symbol is provided, the response is a single object.
+/// If symbols is provided, the response is an array of objects.
+pub enum TickerBookTickerResponse {
+    Single(TickerBookTickerData),
+    List(Vec<TickerBookTickerData>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerBookTickerData {
+    pub symbol: String,
+    pub bid_price: String,
+    pub bid_qty: String,
+    pub ask_price: String,
+    pub ask_qty: String,
+}

--- a/examples/binance-tools/src/api/market_data/ticker_price.rs
+++ b/examples/binance-tools/src/api/market_data/ticker_price.rs
@@ -1,0 +1,60 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "/api/v3/ticker/price";
+
+/// Latest price for a symbol or symbols.
+pub async fn ticker_price(
+    client: &Client,
+    base_url: &str,
+    params: TickerPriceRequest,
+) -> Result<TickerPriceResponse> {
+    if params.symbol.is_none() && params.symbols.is_none() {
+        bail!("Either symbol or symbols must be provided")
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// Request latest price for a symbol or symbols.
+///
+/// **Weight**:
+///
+/// | Parameter | Symbols Provided | Weight |
+/// |-----------|------------------|--------|
+/// | symbol    | 1                | 2      |
+/// |     | symbol parameter is omitted | 4 |
+/// | symbols   | Any              | 4      |
+pub struct TickerPriceRequest {
+    /// Parameter symbol and symbols cannot be used in combination.
+    /// If neither parameter is sent, prices for all symbols will be returned in an array.
+    pub symbol: Option<String>,
+    /// Examples of accepted format for the symbols parameter: ["BTCUSDT","BNBUSDT"]
+    /// or
+    /// %5B%22BTCUSDT%22,%22BNBUSDT%22%5D
+    pub symbols: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+/// If symbol is provided, the response is a single object.
+/// If symbols is provided, the response is an array of objects.
+pub enum TickerPriceResponse {
+    Single(TickerPriceDayData),
+    List(Vec<TickerPriceDayData>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerPriceDayData {
+    pub symbol: String,
+    pub price: String,
+}

--- a/examples/binance-tools/src/api/market_data/ticker_rolling_window_price.rs
+++ b/examples/binance-tools/src/api/market_data/ticker_rolling_window_price.rs
@@ -1,0 +1,109 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::ticker_trading_day::TickerType;
+
+const API_URL: &str = "/api/v3/ticker";
+
+/// Rolling window price change statistics
+pub async fn ticker_rolling_window_price(
+    client: &Client,
+    base_url: &str,
+    mut params: TickerRollingWindowPriceRequest,
+) -> Result<TickerRollingWindowPriceResponse> {
+    if params.symbol.is_none() && params.symbols.is_none() {
+        bail!("Either symbol or symbols must be provided")
+    }
+
+    if params.window_size.is_none() {
+        params.window_size = Some("1d".to_string());
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// **Note**: This endpoint is different from the `GET /api/v3/ticker/24hr` endpoint.
+///
+/// The window used to compute statistics will be no more than 59999ms from the requested `windowSize`.
+///
+/// `openTime` for `/api/v3/ticker` always starts on a minute, while the `closeTime` is the current time of the request. As such, the effective window will be up to 59999ms wider than windowSize.
+///
+/// E.g. If the `closeTime` is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the `windowSize` is `1d`. the `openTime` will be: 1641201420000 (January 3, 2022, 09:17:00)
+///
+/// **Weight**:
+///
+/// 4 for each requested symbol regardless of `windowSize`.
+///
+/// The weight for this request will cap at 200 once the number of symbols in the request is more than 50.
+pub struct TickerRollingWindowPriceRequest {
+    /// Parameter symbol and symbols cannot be used in combination.
+    /// If neither parameter is sent, bookTickers for all symbols will be returned in an array.
+    pub symbol: Option<String>,
+    /// Examples of accepted format for the symbols parameter: ["BTCUSDT","BNBUSDT"]
+    /// or
+    /// %5B%22BTCUSDT%22,%22BNBUSDT%22%5D
+    pub symbols: Option<Vec<String>>,
+    /// Defaults to 1d if no parameter provided
+    /// Supported windowSize values:
+    /// 1m,2m....59m for minutes
+    /// 1h, 2h....23h - for hours
+    /// 1d...7d - for days
+    pub window_size: Option<String>,
+    /// Supported values: FULL or MINI.
+    /// If none provided, the default is FULL
+    pub r#type: Option<TickerType>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+/// If symbol is provided, the response is a single object.
+/// If symbols is provided, the response is an array of objects.
+pub enum TickerRollingWindowPriceResponse {
+    Single(Box<TickerRollingWindowPriceData>),
+    List(Vec<TickerRollingWindowPriceData>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerRollingWindowPriceData {
+    /// Symbol Name
+    pub symbol: String,
+    // --- Fields present in FULL only (marked as Option) ---
+    /// Absolute price change
+    pub price_change: Option<String>,
+    /// Relative price change in percent
+    pub price_change_percent: Option<String>,
+    /// QuoteVolume / Volume
+    pub weighted_avg_price: Option<String>,
+    // --- Fields present in both FULL and MINI ---
+    /// Opening price of the interval
+    pub open_price: String,
+    /// Highest price in the interval
+    pub high_price: String,
+    /// Lowest price in the interval
+    pub low_price: String,
+    /// Closing price of the interval
+    pub last_price: String,
+    /// Total trade volume (in base asset)
+    pub volume: String,
+    /// Total trade volume (in quote asset) - Sum of (price * volume) for all trades
+    pub quote_volume: String,
+    /// Open time for ticker window. Unix timestamp in milliseconds.
+    pub open_time: i64,
+    /// Close time for ticker window. Unix timestamp in milliseconds.
+    pub close_time: i64,
+    /// First tradeId considered
+    pub first_id: i64,
+    /// Last tradeId considered
+    pub last_id: i64,
+    /// Total trade count
+    pub count: i64,
+}

--- a/examples/binance-tools/src/api/market_data/ticker_trading_day.rs
+++ b/examples/binance-tools/src/api/market_data/ticker_trading_day.rs
@@ -1,0 +1,118 @@
+use anyhow::{Result, bail};
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "/api/v3/ticker/tradingDay";
+
+/// Price change statistics for a trading day.
+pub async fn ticker_trading_day(
+    client: &Client,
+    base_url: &str,
+    mut params: TickerTradingDayRequest,
+) -> Result<TickerTradingDayResponse> {
+    if params.r#type.is_none() {
+        params.r#type = Some(TickerType::Full);
+    }
+
+    if params.time_zone.is_none() {
+        params.time_zone = Some("0".to_string());
+    }
+
+    if params.symbol.is_none() && params.symbols.is_none() {
+        bail!("Either symbol or symbols must be provided")
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// **Notes**:
+/// - Supported values for `timeZone`:
+///   - Hours and minutes (e.g. `-1:00`, `05:45`)
+///   - Only hours (e.g. `0`, `8`, `4`)
+///
+/// **Weight**:
+///
+/// 4 for each requested symbol.
+///
+/// The weight for this request will cap at 200 once the number of symbols in the request is more than 50.
+///
+/// **Symbol and Symbols**:
+///
+/// Either symbol or symbols must be provided
+///
+/// Examples of accepted format for the symbols parameter:
+/// ["BTCUSDT","BNBUSDT"]
+/// or
+/// %5B%22BTCUSDT%22,%22BNBUSDT%22%5D
+///
+/// The maximum number of symbols allowed in a request is 100.
+pub struct TickerTradingDayRequest {
+    pub symbol: Option<String>,
+    /// The maximum number of symbols allowed in a request is 100.
+    pub symbols: Option<Vec<String>>,
+    /// Default: 0 (UTC)
+    pub time_zone: Option<String>,
+    /// Supported values: FULL or MINI.
+    /// If none provided, the default is FULL
+    pub r#type: Option<TickerType>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TickerType {
+    Full,
+    Mini,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+/// If symbol is provided, the response is a single object.
+/// If symbols is provided, the response is an array of objects.
+pub enum TickerTradingDayResponse {
+    Single(Box<TickerTradingDayData>),
+    List(Vec<TickerTradingDayData>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TickerTradingDayData {
+    /// Symbol Name
+    pub symbol: String,
+    // --- Fields present in FULL only (marked as Option) ---
+    /// Absolute price change
+    pub price_change: Option<String>,
+    /// Relative price change in percent
+    pub price_change_percent: Option<String>,
+    /// quoteVolume / volume
+    pub weighted_avg_price: Option<String>,
+    // --- Fields present in both FULL and MINI ---
+    /// Opening price of the Interval
+    pub open_price: String,
+    /// Highest price in the interval
+    pub high_price: String,
+    /// Lowest price in the interval
+    pub low_price: String,
+    /// Closing price of the interval
+    pub last_price: String,
+    /// Total trade volume (in base asset)
+    pub volume: String,
+    /// Total trade volume (in quote asset)
+    pub quote_volume: String,
+    /// Start of the ticker interval. Unix timestamp in milliseconds.
+    pub open_time: i64,
+    /// End of the ticker interval. Unix timestamp in milliseconds.
+    pub close_time: i64,
+    /// First tradeId considered
+    pub first_id: i64,
+    /// Last tradeId considered
+    pub last_id: i64,
+    /// Total trade count
+    pub count: i64,
+}

--- a/examples/binance-tools/src/api/market_data/trades.rs
+++ b/examples/binance-tools/src/api/market_data/trades.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+const API_URL: &str = "/api/v3/trades";
+
+/// Get recent trades.
+pub async fn trades(
+    client: &Client,
+    base_url: &str,
+    mut params: TradesRequest,
+) -> Result<TradesResponse> {
+    params.validate()?;
+    if params.limit.is_none() {
+        params.limit = Some(500);
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+pub struct TradesRequest {
+    pub symbol: String,
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<i32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TradesResponse {
+    pub id: i64,
+    pub price: String,
+    pub qty: String,
+    /// Unix timestamp in milliseconds.
+    pub time: i64,
+    pub is_buyer_maker: bool,
+    pub is_best_match: bool,
+}

--- a/examples/binance-tools/src/api/market_data/ui_klines.rs
+++ b/examples/binance-tools/src/api/market_data/ui_klines.rs
@@ -1,0 +1,97 @@
+use anyhow::Result;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+use super::klines::KLineInterval;
+
+const API_URL: &str = "/api/v3/uiKlines";
+
+/// The request is similar to klines having the same parameters and response.
+/// uiKlines return modified kline data, optimized for presentation of candlestick charts
+pub async fn ui_klines(
+    client: &Client,
+    base_url: &str,
+    mut params: UIKlinesRequest,
+) -> Result<Vec<UIKlinesResponse>> {
+    params.validate()?;
+    if params.limit.is_none() {
+        params.limit = Some(500);
+    }
+
+    if params.time_zone.is_none() {
+        params.time_zone = Some("0".to_owned());
+    }
+
+    let url = format!("{}{}", base_url, API_URL);
+    let response = client.get(&url).query(&params).send().await?;
+    response.error_for_status_ref()?;
+
+    Ok(response.json().await?)
+}
+
+#[derive(Debug, Validate, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+/// The request is similar to klines having the same parameters and response.
+/// uiKlines return modified kline data, optimized for presentation of candlestick charts.
+///
+/// - If `startTime` and `endTime` are not sent, the most recent klines are returned.
+/// - Supported values for `timeZone`:
+///   - Hours and minutes (e.g. `-1:00`, `05:45`)
+///   - Only hours (e.g. `0`, `8`, `4`)
+///   - Accepted range is strictly [-12:00 to +14:00] inclusive
+/// - If `timeZone` provided, kline intervals are interpreted in that `timezone` instead of UTC.
+/// - Note that `startTime` and `endTime` are always interpreted in UTC, regardless of `timeZone`.
+pub struct UIKlinesRequest {
+    pub symbol: String,
+    /// K-line interval
+    pub interval: KLineInterval,
+    pub start_time: Option<i64>,
+    pub end_time: Option<i64>,
+    /// time zone, default: 0(UTC)
+    pub time_zone: Option<String>,
+    #[validate(range(min = 1, max = 1000))]
+    pub limit: Option<i32>,
+}
+
+/// 0: Kline open time. Unix timestamp in milliseconds.
+/// 1: Open price
+/// 2: High price
+/// 3: Low price
+/// 4: Close price
+/// 5: Volume
+/// 6: Kline close time. Unix timestamp in milliseconds.
+/// 7: Quote asset volume
+/// 8: Number of trades
+/// 9: Taker buy base asset volume
+/// 10: Taker buy quote asset volume
+/// 11: Unused field. Ignore.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UIKlinesResponse(
+    /// 0: Kline open time. Unix timestamp in milliseconds.
+    pub i64,
+    /// 1: Open price
+    pub String,
+    /// 2: High price
+    pub String,
+    /// 3: Low price
+    pub String,
+    /// 4: Close price
+    pub String,
+    /// 5: Volume
+    pub String,
+    /// 6: Kline close time. Unix timestamp in milliseconds.
+    pub i64,
+    /// 7: Quote asset volume
+    pub String,
+    /// 8: Number of trades
+    pub i64,
+    /// 9: Taker buy base asset volume
+    pub String,
+    /// 10: Taker buy quote asset volume
+    pub String,
+    /// 11: Unused field. Ignore.
+    pub String,
+);

--- a/examples/binance-tools/src/api/mod.rs
+++ b/examples/binance-tools/src/api/mod.rs
@@ -1,0 +1,3 @@
+pub mod account;
+pub mod market_data;
+pub mod trading;

--- a/examples/binance-tools/src/auth.rs
+++ b/examples/binance-tools/src/auth.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+#[allow(dead_code)]
+type HmacSha256 = Hmac<Sha256>;
+
+#[allow(unused)]
+/// get hmac signature(hex)
+pub fn get_hmac_signature(secret_key: &str, data: &str) -> Result<String> {
+    let mut mac = HmacSha256::new_from_slice(secret_key.as_bytes())?;
+    mac.update(data.as_bytes());
+    let result = mac.finalize().into_bytes();
+
+    Ok(hex::encode(result))
+}

--- a/examples/binance-tools/src/main.rs
+++ b/examples/binance-tools/src/main.rs
@@ -1,0 +1,58 @@
+use std::env;
+
+use mcp_tools::BinanceMCPTools;
+use rmcp::{
+    ServiceExt,
+    transport::{SseServer, stdio},
+};
+use tracing_subscriber::EnvFilter;
+
+// examples/binance-mcp/src/main.rs
+mod api;
+mod auth;
+mod mcp_tools;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting Binance MCP Server...");
+
+    let (ctrlc_tx, ctrlc_rx) = tokio::sync::oneshot::channel::<()>();
+    let (sse_cancel_tx, sse_cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    tokio::spawn(async move {
+        let sse_addr = env::var("BINANCE_MCP_SSE_ADDR")
+            .unwrap_or("0.0.0.0:8000".parse().unwrap())
+            .parse()
+            .expect("Invalid SSE address");
+        tracing::info!("Starting SSE server at {}", sse_addr);
+        let ct = SseServer::serve(sse_addr)
+            .await
+            .expect("Failed to start SSE server")
+            .with_service(BinanceMCPTools::new);
+
+        tokio::select! {
+            _ = ctrlc_rx => {
+                ct.cancel();
+                sse_cancel_tx.send(()).unwrap();
+            }
+        }
+    });
+
+    tracing::info!("Starting STDIO server...");
+    let service = BinanceMCPTools::new().serve(stdio()).await?;
+
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("Stopping Binance MCP Server...");
+
+    ctrlc_tx.send(()).unwrap();
+    service.cancel().await.unwrap();
+    sse_cancel_rx.await.unwrap();
+
+    tracing::info!("Binance MCP Server stopped.");
+    Ok(())
+}

--- a/examples/binance-tools/src/mcp_tools.rs
+++ b/examples/binance-tools/src/mcp_tools.rs
@@ -1,0 +1,190 @@
+use reqwest::Client;
+use rmcp::{
+    Error as MCPError, ServerHandler,
+    model::{CallToolResult, Content, ServerInfo},
+    tool,
+};
+
+use crate::api::market_data::{
+    self, agg_trades, avg_price, depth, historical_trades, klines, ticker_24hr, ticker_book_ticker,
+    ticker_price, ticker_rolling_window_price, ticker_trading_day, trades, ui_klines,
+};
+
+macro_rules! call_api_tool {
+    ($self:expr, $api_function:path, $params:expr) => {
+        match $api_function(&$self.client, &$self.base_url, $params).await {
+            Ok(res) => CallToolResult::success(vec![Content::json(res)?]),
+            Err(err) => CallToolResult::error(vec![Content::text(err.to_string())]),
+        }
+    };
+}
+
+#[derive(Clone)]
+pub struct BinanceMCPTools {
+    pub base_url: String,
+    pub client: Client,
+}
+
+#[tool(tool_box)]
+impl BinanceMCPTools {
+    pub fn new() -> Self {
+        Self {
+            base_url: "https://api.binance.com".to_owned(),
+            client: Client::new(),
+        }
+    }
+
+    #[tool(
+        description = "Get compressed, aggregate trades. Trades that fill at the time, from the same taker order, with the same price will have the quantity aggregated."
+    )]
+    async fn agg_trades(
+        &self,
+        #[tool(aggr)] params: agg_trades::AggTradesRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::agg_trades, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Get current average price for a symbol.")]
+    async fn avg_price(
+        &self,
+        #[tool(aggr)] params: avg_price::AvgPriceRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::avg_price, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Get depth information.")]
+    async fn depth(
+        &self,
+        #[tool(aggr)] params: depth::DepthRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::depth, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Get older trades.")]
+    async fn historical_trades(
+        &self,
+        #[tool(aggr)] params: historical_trades::HistoricalTradesRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::historical_trades, params);
+        Ok(result)
+    }
+
+    #[tool(description = "
+        Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+        
+        Response array:
+            0: Kline open time
+            1: Open price
+            2: High price
+            3: Low price
+            4: Close price
+            5: Volume
+            6: Kline close time
+            7: Quote asset volume
+            8: Number of trades
+            9: Taker buy base asset volume
+            10: Taker buy quote asset volume
+            11: Unused field. Ignore.
+        ")]
+    async fn klines(
+        &self,
+        #[tool(aggr)] params: klines::KlinesRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::klines, params);
+        Ok(result)
+    }
+
+    #[tool(
+        description = "24 hour rolling window price change statistics. Careful when accessing this with no symbol."
+    )]
+    async fn ticker_24hr(
+        &self,
+        #[tool(aggr)] params: ticker_24hr::Ticker24HrRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ticker_24hr, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Best price/qty on the order book for all symbols.")]
+    async fn ticker_book_ticker(
+        &self,
+        #[tool(aggr)] params: ticker_book_ticker::TickerBookTickerRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ticker_book_ticker, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Latest price for all symbols or for a symbol.")]
+    async fn ticker_price(
+        &self,
+        #[tool(aggr)] params: ticker_price::TickerPriceRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ticker_price, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Latest price for a symbol with 24 hour rolling window.")]
+    async fn ticker_rolling_window_price(
+        &self,
+        #[tool(aggr)] params: ticker_rolling_window_price::TickerRollingWindowPriceRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ticker_rolling_window_price, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Price change statistics for a trading day.")]
+    async fn ticker_trading_day(
+        &self,
+        #[tool(aggr)] params: ticker_trading_day::TickerTradingDayRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ticker_trading_day, params);
+        Ok(result)
+    }
+
+    #[tool(description = "Recent trades list.")]
+    async fn trades(
+        &self,
+        #[tool(aggr)] params: trades::TradesRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::trades, params);
+        Ok(result)
+    }
+
+    #[tool(description = "
+        The request is similar to klines having the same parameters and response. uiKlines return modified kline data, optimized for presentation of candlestick charts.
+                
+        Response array:
+            0: Kline open time
+            1: Open price
+            2: High price
+            3: Low price
+            4: Close price
+            5: Volume
+            6: Kline close time
+            7: Quote asset volume
+            8: Number of trades
+            9: Taker buy base asset volume
+            10: Taker buy quote asset volume
+            11: Unused field. Ignore.
+        ")]
+    async fn ui_klines(
+        &self,
+        #[tool(aggr)] params: ui_klines::UIKlinesRequest,
+    ) -> Result<CallToolResult, MCPError> {
+        let result = call_api_tool!(self, market_data::ui_klines, params);
+        Ok(result)
+    }
+}
+
+#[tool(tool_box)]
+impl ServerHandler for BinanceMCPTools {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            instructions: Some("Binance API".to_owned()),
+            ..Default::default()
+        }
+    }
+}

--- a/swarms-rs/src/agent/swarms_agent.rs
+++ b/swarms-rs/src/agent/swarms_agent.rs
@@ -14,11 +14,15 @@ use rmcp::{
     model::{ClientCapabilities, ClientInfo, Implementation},
     transport::{SseTransport, TokioChildProcess},
 };
-use serde::Serialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use swarms_macro::tool;
+use thiserror::Error;
 use tokio::{process::Command, sync::mpsc};
 use twox_hash::XxHash3_64;
 
 use crate::{
+    self as swarms_rs,
     llm::{
         self,
         request::{CompletionRequest, ToolDefinition},
@@ -127,7 +131,15 @@ where
         })
     }
 
-    pub fn build(self) -> SwarmsAgent<M> {
+    pub fn build(mut self) -> SwarmsAgent<M> {
+        if self.config.task_evaluator_tool_enabled {
+            self.tools.insert(0, ToolDyn::definition(&TaskEvaluator));
+            self.tools_impl.insert(
+                ToolDyn::name(&TaskEvaluator),
+                Arc::new(TaskEvaluator) as Arc<dyn ToolDyn>,
+            );
+        }
+
         SwarmsAgent {
             model: self.model,
             config: self.config,
@@ -206,6 +218,11 @@ where
             .into_iter()
             .fold(self, |builder, stop_word| builder.add_stop_word(stop_word))
     }
+
+    pub fn disable_task_complete_tool(mut self) -> Self {
+        self.config.task_evaluator_tool_enabled = false;
+        self
+    }
 }
 
 #[derive(Clone, Serialize)]
@@ -243,11 +260,13 @@ where
         &self,
         prompt: impl Into<String>,
         chat_history: impl Into<Vec<llm::completion::Message>>,
-    ) -> Result<String, AgentError> {
+    ) -> Result<ChatResponse, AgentError> {
+        let chat_history = chat_history.into();
+
         let request = CompletionRequest {
             prompt: llm::completion::Message::user(prompt),
             system_prompt: self.system_prompt.clone(),
-            chat_history: chat_history.into(),
+            chat_history,
             tools: self.tools.clone(),
             temperature: Some(self.config.temperature),
             max_tokens: Some(self.config.max_tokens),
@@ -257,7 +276,7 @@ where
 
         let choice = response.choice.first().ok_or(AgentError::NoChoiceFound)?;
         match ToOwned::to_owned(choice) {
-            llm::completion::AssistantContent::Text(text) => Ok(text.text),
+            llm::completion::AssistantContent::Text(text) => Ok(ChatResponse::Text(text.text)), // <--- return Text
             llm::completion::AssistantContent::ToolCall(tool_call) => {
                 let mut all_tool_calls = vec![tool_call.function];
                 all_tool_calls.extend(response.choice.iter().skip(1).filter_map(|choice| {
@@ -278,22 +297,37 @@ where
                             .deref(),
                     );
                     let args = tool_call.arguments.to_string();
-                    let result = tool.call(args).await?;
-                    results.push((tool_call.name, result));
+                    // execute tool
+                    let result_str = tool.call(args.clone()).await?;
+                    // collect results
+                    results.push(ToolCallOutput {
+                        name: tool_call.name.clone(),
+                        args,
+                        result: result_str,
+                    });
                 }
 
-                if results.len() == 1 {
-                    Ok(results[0].1.clone())
-                } else {
-                    let mut combined_result = String::new();
-                    for (tool_name, tool_result) in results {
-                        combined_result.push_str(&format!(
-                            "[Tool name]: {}\n[Tool result]: {}\n\n",
-                            tool_name, tool_result
-                        ));
-                    }
-                    Ok(combined_result)
-                }
+                Ok(ChatResponse::ToolCalls(results))
+            },
+        }
+    }
+
+    pub async fn prompt(&self, prompt: impl Into<String>) -> Result<String, AgentError> {
+        let prompt = prompt.into();
+        let request = CompletionRequest {
+            prompt: llm::completion::Message::user(prompt),
+            system_prompt: self.system_prompt.clone(),
+            chat_history: vec![],
+            tools: vec![],
+            temperature: Some(self.config.temperature),
+            max_tokens: Some(self.config.max_tokens),
+        };
+        let response = self.model.completion(request).await?;
+        let choice = response.choice.first().ok_or(AgentError::NoChoiceFound)?;
+        match ToOwned::to_owned(choice) {
+            llm::completion::AssistantContent::Text(text) => Ok(text.text),
+            llm::completion::AssistantContent::ToolCall(_) => {
+                unreachable!("We don't provide tools")
             },
         }
     }
@@ -359,9 +393,45 @@ where
             }
 
             // Run agent loop
-            let mut last_response = String::new();
+            let mut last_response_text = String::new();
             let mut all_responses = vec![];
-            for _loop_count in 0..self.config.max_loops {
+            let mut task_complete = false;
+            let mut was_prev_call_task_evaluator = false;
+            for loop_count in 0..self.config.max_loops {
+                if task_complete {
+                    break;
+                }
+
+                let current_prompt: String;
+
+                if was_prev_call_task_evaluator {
+                    current_prompt = format!(
+                        "You previously called task_evaluator and indicated the task was not complete. The required next step or context provided was: '{}'. \
+                        Focus ONLY on addressing this context. DO NOT call task_evaluator again in this turn. Proceed with the task based on the context.",
+                        last_response_text // last_response is the context provided by task_evaluator
+                    );
+
+                    was_prev_call_task_evaluator = false;
+                } else if loop_count > 0 {
+                    current_prompt = format!(
+                        "Now, you are in loop {} of {}, The dialogue will terminate upon reaching maximum iteration count. You must:
+                         - Complete the user's task before termination
+                         - Optimize loop efficiency
+                         - Minimize resource consumption through minimal iterations
+
+                        You should consider to use tools if they can help, but only if they are relevant to the task and are necessary for the task.
+                        origin task:\n{}",
+                        loop_count + 1,
+                        self.config.max_loops,
+                        task
+                    )
+                } else {
+                    // first loop
+                    // task is already in short_memory, short_memory will be passed to llm
+                    // empty prompt should be ignored by LLM provider
+                    current_prompt = "".to_owned();
+                }
+
                 let mut success = false;
                 // let task_prompt = self.short_memory.0.get(&task).unwrap().to_string(); // Safety: task is in short_memory
                 for attempt in 0..self.config.retry_attempts {
@@ -379,29 +449,119 @@ where
 
                     // Generate response using LLM
                     let history = self.short_memory.0.get(&task).unwrap(); // Safety: task is in short_memory
-                    last_response = match self.chat(&task, history.deref()).await {
-                        Ok(response) => response,
-                        Err(e) => {
-                            self.handle_error_in_attempts(&task, e, attempt).await;
-                            continue;
-                        },
-                    };
+                    let current_chat_response =
+                        match self.chat(&current_prompt, history.deref()).await {
+                            Ok(response) => response,
+                            Err(e) => {
+                                self.handle_error_in_attempts(&task, e, attempt).await;
+                                continue;
+                            },
+                        };
                     // needed to drop the lock
                     // if use:
                     // let history = (&(*self.short_memory.0.get(&task).unwrap())).into();
                     // we don't need to drop the lock, because the lock is owned by temporary variable
                     drop(history);
 
-                    // Add response to memory
+                    // handle ChatResponse
+                    let mut assistant_memory_content = String::new();
+                    let mut is_task_evaluator_called = false;
+                    match current_chat_response {
+                        ChatResponse::Text(text) => {
+                            last_response_text = text.clone();
+                            assistant_memory_content = text;
+                        },
+                        ChatResponse::ToolCalls(tool_calls) => {
+                            let mut formatted_tool_results = String::new();
+                            for tool_call in tool_calls {
+                                let formatted = format!(
+                                    "[Tool name]: {}\n[Tool args]: {}\n[Tool result]: {}\n\n",
+                                    tool_call.name, tool_call.args, tool_call.result
+                                );
+                                formatted_tool_results.push_str(&formatted);
+                                if tool_call.name == ToolDyn::name(&TaskEvaluator) {
+                                    is_task_evaluator_called = true;
+                                    match serde_json::from_str::<TaskStatus>(&tool_call.result) {
+                                        Ok(task_status) => {
+                                            tracing::info!(
+                                                "Task complete tool called, task status: {:#?}",
+                                                task_status,
+                                            );
+
+                                            task_complete = task_status.is_complete;
+                                            if !task_complete {
+                                                // If not complete, store the context for the next loop's prompt
+                                                last_response_text = task_status.context.unwrap_or_else(|| {
+                                                    tracing::warn!("Task evaluator returned incomplete status without context.");
+                                                    "Task incomplete, continue working.".to_string()
+                                                });
+                                                // Keep the raw tool result for memory
+                                                assistant_memory_content = formatted;
+                                            } else {
+                                                // Task is complete
+                                                // This may be a bit redundant, but it's here for clarity
+                                                // last_response_text = format!(
+                                                //     "Task marked as complete by task_evaluator. Result: {}",
+                                                //     tool_call.result
+                                                // );
+                                                assistant_memory_content = formatted; // Store the final tool call in memory
+                                            }
+                                        },
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "Failed to parse task status from task_evaluator: {}. Raw result: {}",
+                                                e,
+                                                tool_call.result
+                                            );
+
+                                            task_complete = false;
+
+                                            last_response_text = format!(
+                                                "Error parsing task_evaluator result. Raw output: {}",
+                                                tool_call.result
+                                            );
+                                            assistant_memory_content = formatted; // Store the problematic call
+                                        },
+                                    }
+                                } else {
+                                    // Handle other tool calls if necessary, for now just format them
+                                    // If this is the *only* response part, update last_response_text
+                                    if formatted_tool_results.len() == formatted.len() {
+                                        // Check if it's the first/only tool result string being built
+                                        last_response_text = formatted_tool_results.clone();
+                                    } else {
+                                        // Append to existing text/tool results for the final response string
+                                        last_response_text.push_str(&formatted);
+                                    }
+                                }
+                            }
+                            // If multiple tools were called, or if task_evaluator wasn't the only one,
+                            // ensure assistant_memory_content reflects all calls.
+                            if assistant_memory_content.is_empty() || !is_task_evaluator_called {
+                                assistant_memory_content = formatted_tool_results.clone();
+                                // Update last_response_text if it wasn't set by task_evaluator
+                                if !is_task_evaluator_called {
+                                    last_response_text = formatted_tool_results;
+                                }
+                            }
+                        },
+                    }
+
+                    // Update the flag for the *next* iteration based on *this* iteration's call
+                    was_prev_call_task_evaluator = is_task_evaluator_called && !task_complete;
+
                     self.short_memory.add(
                         &task,
                         &self.config.name,
                         Role::Assistant(self.config.name.to_owned()),
-                        last_response.clone(),
+                        assistant_memory_content.clone(), // Add the text or formatted tool calls
                     );
 
-                    // Add response to all_responses
-                    all_responses.push(last_response.clone());
+                    // Add meaningful text response to all_responses
+                    // Avoid adding raw tool call formatting unless it's the final completion message
+                    if !is_task_evaluator_called || task_complete {
+                        all_responses.push(last_response_text.clone());
+                    }
 
                     // TODO: evaluate response
                     // TODO: Sentiment analysis
@@ -414,7 +574,12 @@ where
                     break;
                 }
 
-                if self.is_response_complete(last_response.clone()) {
+                // Save state in each loop
+                if self.config.autosave {
+                    self.save_task_state(task.clone()).await?;
+                }
+
+                if self.is_response_complete(last_response_text.clone()) {
                     break;
                 }
 
@@ -477,7 +642,7 @@ where
         Box::pin(async move {
             if let Some(planning_prompt) = &self.config.planning_prompt {
                 let planning_prompt = format!("{} {}", planning_prompt, task);
-                let plan = self.chat(planning_prompt, vec![]).await?;
+                let plan = self.prompt(planning_prompt).await?;
                 tracing::debug!("Plan: {}", plan);
                 // Add plan to memory
                 self.short_memory.add(
@@ -543,3 +708,63 @@ where
         Box::new(self.clone())
     }
 }
+
+/// Represents the output of the chat function, distinguishing text from tool calls.
+#[derive(Debug, Clone)]
+pub enum ChatResponse {
+    /// Plain text response from the LLM.
+    Text(String),
+    /// Results from executing one or more tool calls requested by the LLM.
+    ToolCalls(Vec<ToolCallOutput>),
+}
+
+/// Holds the details of a single executed tool call.
+#[derive(Debug, Clone, Serialize, Deserialize)] // Added Serialize/Deserialize for potential future use
+pub struct ToolCallOutput {
+    /// The name of the tool that was called.
+    pub name: String,
+    /// The arguments (as a JSON string) passed to the tool.
+    pub args: String,
+    /// The result (as a string) returned by the tool's execution.
+    pub result: String,
+}
+
+#[tool(description = r#"
+    **Important**
+    If previous message is a `task_evaluator` call, then you shouldn't call this tool.
+
+    **Task Evaluator**
+    Finalize or request refinement for the current task.
+    
+    Call this when:
+    - All user requirements are fully satisfied (set is_complete=true)
+    - Avoids unnecessary iterations, redundancy, or waste.
+    - Additional input/clarification is needed (set is_complete=false with context)
+    
+    When is_complete=true, the context is ignored, because the dialogue will terminate.
+    When is_complete=false, your context becomes the system's next prompt, enabling iterative task refinement.
+    Provide clear, actionable contexts to guide the next steps, the context should be used to guide yourself to complete the task.
+"#)]
+fn task_evaluator(status: TaskStatus) -> Result<TaskStatus, TaskEvaluatorError> {
+    Ok(status)
+}
+
+/// Tracks task completion state and provides feedback for incomplete tasks.
+/// When `is_complete` is false, the `context` becomes the system's next prompt.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct TaskStatus {
+    /// Final completion state.
+    /// Set to true ONLY when all requirements are fully satisfied.
+    pub is_complete: bool,
+
+    /// Required guidance when task is incomplete:
+    /// - Clear description of missing elements
+    /// - Specific questions needing clarification  
+    /// - Remaining steps to completion
+    ///
+    /// Optional when task is complete.
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum TaskEvaluatorError {}

--- a/swarms-rs/src/agent/swarms_agent.rs
+++ b/swarms-rs/src/agent/swarms_agent.rs
@@ -394,7 +394,6 @@ where
 
             // Run agent loop
             let mut last_response_text = String::new();
-            let mut all_responses = vec![];
             let mut task_complete = false;
             let mut was_prev_call_task_evaluator = false;
             for loop_count in 0..self.config.max_loops {
@@ -557,12 +556,6 @@ where
                         assistant_memory_content.clone(), // Add the text or formatted tool calls
                     );
 
-                    // Add meaningful text response to all_responses
-                    // Avoid adding raw tool call formatting unless it's the final completion message
-                    if !is_task_evaluator_called || task_complete {
-                        all_responses.push(last_response_text.clone());
-                    }
-
                     // TODO: evaluate response
                     // TODO: Sentiment analysis
 
@@ -597,7 +590,12 @@ where
             // TODO: Handle artifacts
 
             // TODO: More flexible output types, e.g. JSON, CSV, etc.
-            Ok(all_responses.concat())
+            Ok(self
+                .short_memory
+                .0
+                .get(&task)
+                .expect("Task should exist in short memory")
+                .to_string())
         })
     }
 

--- a/swarms-rs/src/lib.rs
+++ b/swarms-rs/src/lib.rs
@@ -3,3 +3,5 @@
 pub mod agent;
 pub mod llm;
 pub mod structs;
+
+pub use swarms_macro;

--- a/swarms-rs/src/llm/completion.rs
+++ b/swarms-rs/src/llm/completion.rs
@@ -183,8 +183,6 @@ pub enum ImageDetail {
 // ================================================================
 
 impl Message {
-    // TODO: Remove this macro
-    #[allow(dead_code)]
     /// This helper method is primarily used to extract the first string prompt from a `Message`.
     /// Since `Message` might have more than just text content, we need to find the first text.
     pub(crate) fn rag_text(&self) -> Option<String> {
@@ -192,6 +190,9 @@ impl Message {
             Message::User { content } => {
                 for item in content.iter() {
                     if let UserContent::Text(Text { text }) = item {
+                        if text.is_empty() {
+                            continue;
+                        }
                         return Some(text.clone());
                     }
                 }

--- a/swarms-rs/src/llm/provider/openai.rs
+++ b/swarms-rs/src/llm/provider/openai.rs
@@ -123,8 +123,10 @@ impl Model for OpenAI {
 
             msgs.extend(chat_history);
 
-            let prompt: Vec<ChatCompletionRequestMessage> = request.prompt.try_into()?;
-            msgs.extend(prompt);
+            if request.prompt.rag_text().is_some() {
+                let prompt: Vec<ChatCompletionRequestMessage> = request.prompt.try_into()?;
+                msgs.extend(prompt);
+            }
 
             let mut create_request_builder = CreateChatCompletionRequestArgs::default();
             if let Some(max_tokens) = request.max_tokens {

--- a/swarms-rs/src/structs/agent.rs
+++ b/swarms-rs/src/structs/agent.rs
@@ -127,6 +127,7 @@ pub struct AgentConfig {
     pub rag_every_loop: bool,
     pub save_state_dir: Option<String>,
     pub stop_words: HashSet<String>,
+    pub task_evaluator_tool_enabled: bool,
 }
 
 impl AgentConfig {
@@ -154,6 +155,7 @@ impl Default for AgentConfig {
             rag_every_loop: false,
             save_state_dir: None,
             stop_words: HashSet::new(),
+            task_evaluator_tool_enabled: true,
         }
     }
 }

--- a/swarms-rs/src/structs/concurrent_workflow.rs
+++ b/swarms-rs/src/structs/concurrent_workflow.rs
@@ -280,23 +280,19 @@ mod tests {
         assert_eq!(result_history[0].role, Role::User("User".to_owned()));
 
         let Content::Text(content0) = result_history[0].content.clone();
-        // should be like "Time: 1742525911 \ntest task"
-        assert!(content0.contains("Time:"));
+        assert!(content0.contains("Timestamp(millis):"));
         assert!(content0.contains("test task"));
 
         let Content::Text(content1) = result_history[1].content.clone();
-        // should be like "Time: 1742525911 \nresponse1"
-        assert!(content1.contains("Time:"));
+        assert!(content1.contains("Timestamp(millis):"));
         assert!(content1.contains("response1"));
 
         let Content::Text(content2) = result_history[2].content.clone();
-        // should be like "Time: 1742525911 \nresponse2"
-        assert!(content2.contains("Time:"));
+        assert!(content2.contains("Timestamp(millis):"));
         assert!(content2.contains("response2"));
 
         let Content::Text(content3) = result_history[3].content.clone();
-        // should be like "Time: 1742525911 \nresponse3"
-        assert!(content3.contains("Time:"));
+        assert!(content3.contains("Timestamp(millis):"));
         assert!(content3.contains("response3"));
     }
 
@@ -330,17 +326,17 @@ mod tests {
             // Because agents are executed concurrently, the order of the responses is not guaranteed.
             assert!(result_history.iter().skip(1).any(|msg| {
                 let Content::Text(content) = msg.content.clone();
-                content.contains("Time:") && content.contains("response1")
+                content.contains("Timestamp(millis):") && content.contains("response1")
             }));
 
             assert!(result_history.iter().skip(1).any(|msg| {
                 let Content::Text(content) = msg.content.clone();
-                content.contains("Time:") && content.contains("response2")
+                content.contains("Timestamp(millis):") && content.contains("response2")
             }));
 
             assert!(result_history.iter().skip(1).any(|msg| {
                 let Content::Text(content) = msg.content.clone();
-                content.contains("Time:") && content.contains("response3")
+                content.contains("Timestamp(millis):") && content.contains("response3")
             }));
         }
     }

--- a/swarms-rs/src/structs/conversation.rs
+++ b/swarms-rs/src/structs/conversation.rs
@@ -67,10 +67,10 @@ impl AgentConversation {
 
     /// Add a message to the conversation history.
     pub fn add(&mut self, role: Role, message: String) {
-        let timestamp = Local::now().timestamp();
+        let timestamp = Local::now().timestamp_millis();
         let message = Message {
             role,
-            content: Content::Text(format!("Time: {timestamp} \n{message}")),
+            content: Content::Text(format!("Timestamp(millis): {timestamp} \n{message}")),
         };
         self.history.push(message);
 


### PR DESCRIPTION
Each example is setup as its own crate so its dependencies are clear.

Introduces a new `binance-tools` module that provides functionality to interact with Binance's market data APIs. It includes endpoints for fetching market data such as tickers, trades, klines, and depth information. The module is structured to support easy integration and extensibility for future Binance API endpoints.

Additionally, this pr includes a new `binance-swarms-agent` example that demonstrates how to use the `binance-tools` module in conjunction with the `swarms-rs` library to create a crypto trading strategist agent. The agent leverages the Binance API to provide market analysis and trading strategies based on real-time data.