### PR TITLE
 Add Default Value for base_url in Configuration

### DIFF
--- a/swarms-rs/examples/simple_agent.rs
+++ b/swarms-rs/examples/simple_agent.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let base_url = env::var("DEEPSEEK_BASE_URL").unwrap();
+    let base_url = env::var("DEEPSEEK_BASE_URL").unwrap_or("https://api.deepseek.com".to_string());
     let api_key = env::var("DEEPSEEK_API_KEY").unwrap();
     let client = OpenAI::from_url(base_url, api_key).set_model("deepseek-chat");
     let agent = client


### PR DESCRIPTION
### Pull Request Description

**File:** `swarms-rs\examples\simple_agent.rs`

**Summary:**
This pull request adds a default value for the `base_url` variable in the code. 

**Details:**
- The `base_url` retrieves the `DEEPSEEK_BASE_URL` environment variable.
- If the environment variable is not set, it defaults to 'https://api.deepseek.com'.

**Reason for Change:**
This change ensures that the application has a fallback URL, improving its robustness when the environment variable is not defined.
