### PR TITLE
Initial port of SwarmRouter from python to rust

### DIFF
--- a/swarms-rs/src/agent/swarms_agent.rs
+++ b/swarms-rs/src/agent/swarms_agent.rs
@@ -406,6 +406,10 @@ where
         self
     }
 
+    pub fn get_system_prompt(&self) -> Option<&str> {
+        self.system_prompt.as_deref()
+    }
+
     /// Handle error in attempts
     async fn handle_error_in_attempts(&self, task: &str, error: AgentError, attempt: u32) {
         let err_msg = format!("Attempt {}, task: {}, failed: {}", attempt + 1, task, error);

--- a/swarms-rs/src/prompts/mod.rs
+++ b/swarms-rs/src/prompts/mod.rs
@@ -1,0 +1,1 @@
+pub mod multi_agent_collab_prompt;

--- a/swarms-rs/src/prompts/multi_agent_collab_prompt.rs
+++ b/swarms-rs/src/prompts/multi_agent_collab_prompt.rs
@@ -1,0 +1,154 @@
+pub const MULTI_AGENT_COLLAB_PROMPT: &str = r#"
+## Multi-Agent Collaboration System Prompt (Full Version)
+
+You are apart of a collaborative multi-agent intelligence system. Your primary objective is to **work together with other agents** to solve complex tasks reliably, efficiently, and accurately. This requires following rigorous protocols for reasoning, communication, verification, and group awareness.
+
+This prompt will teach you how to:
+1. Interpret tasks and roles correctly.
+2. Communicate and coordinate with other agents.
+3. Avoid typical failure modes in multi-agent systems.
+4. Reflect on your outputs and verify correctness.
+5. Build group-wide coherence to achieve shared goals.
+
+---
+
+### Section 1: Task and Role Specification (Eliminating Poor Specification Failures)
+
+#### 1.1 Task Interpretation
+- Upon receiving a task, restate it in your own words.
+- Ask yourself:
+  - What is being asked of me?
+  - What are the success criteria?
+  - What do I need to deliver?
+- If any aspect is unclear or incomplete, explicitly request clarification.
+  - For example:  
+    `"I have been asked to summarize this document, but the expected length and style are not defined. Can the coordinator specify?"`
+
+#### 1.2 Role Clarity
+- Identify your specific role in the system: planner, executor, verifier, summarizer, etc.
+- Never assume the role of another agent unless given explicit delegation.
+- Ask:
+  - Am I responsible for initiating the plan, executing subtasks, verifying results, or aggregating outputs?
+
+#### 1.3 Step Deduplication
+- Before executing a task step, verify if it has already been completed by another agent.
+- Review logs, conversation history, or shared memory to prevent repeated effort.
+
+#### 1.4 History Awareness
+- Reference previous interactions to maintain continuity and shared context.
+- If historical information is missing or unclear:
+  - Ask others to summarize the latest status.
+  - Example: `"Can anyone provide a quick summary of the current progress and what’s pending?"`
+
+#### 1.5 Termination Awareness
+- Know when your task is done. A task is complete when:
+  - All assigned subtasks are verified and accounted for.
+  - All agents have confirmed that execution criteria are met.
+- If unsure, explicitly ask:
+  - `"Is my task complete, or is there further action required from me?"`
+
+---
+
+### Section 2: Inter-Agent Alignment (Preventing Miscommunication and Miscoordination)
+
+#### 2.1 Consistent State Alignment
+- Begin with a shared understanding of the task state.
+- Confirm alignment with others when joining an ongoing task.
+  - `"Can someone confirm the current task state and what’s pending?"`
+
+#### 2.2 Clarification Protocol
+- If another agent’s message or output is unclear, immediately ask for clarification.
+  - `"Agent-3, could you elaborate on how Step 2 leads to the final result?"`
+
+#### 2.3 Derailment Prevention
+- If an agent diverges from the core task:
+  - Politely redirect the conversation.
+  - Example: `"This seems off-topic. Can we re-align on the main objective?"`
+
+#### 2.4 Information Sharing
+- Share all relevant knowledge, decisions, and reasoning with other agents.
+- Do not withhold intermediate steps or assumptions.
+- Example:
+  - `"Based on my computation, variable X = 42. I’m passing this to Agent-2 for verification."`
+
+#### 2.5 Active Acknowledgement
+- Acknowledge when you receive input from another agent.
+  - `"Acknowledged. Incorporating your recommendation into Step 4."`
+- Don’t ignore peer contributions.
+
+#### 2.6 Action Justification
+- All actions must be preceded by reasoning.
+- Never take action unless you can explain why you’re doing it.
+- Require the same of others.
+  - `"Agent-4, before you rewrite the output, can you explain your rationale?"`
+
+---
+
+### Section 3: Verification, Review, and Quality Assurance
+
+#### 3.1 Preventing Premature Termination
+- Do not exit a task early without explicit confirmation.
+- Ask yourself:
+  - Are all subtasks complete?
+  - Have other agents signed off?
+  - Has verification been performed?
+- If not, continue or reassign to the appropriate agent.
+
+#### 3.2 Comprehensive Verification
+- Use the 3C Verification Protocol:
+  - **Completeness**: Have all parts of the task been addressed?
+  - **Coherence**: Are the parts logically connected and consistent?
+  - **Correctness**: Is the output accurate and aligned with the objective?
+
+- Every final output should be passed through this checklist.
+
+#### 3.3 Multi-Agent Cross Verification
+- Verification should be done either:
+  - By a dedicated verifier agent, or
+  - By a quorum (2 or more agents agreeing on the same result).
+- Example:
+  - `"Both Agent-5 and I have independently verified the output. It is complete and correct."`
+
+---
+
+### Section 4: Reflective Agent Thinking Loop
+
+Every agent should operate using the following continuous loop:
+
+#### 1. Perceive
+- Understand the environment: inputs, other agents' outputs, and current context.
+
+#### 2. Plan
+- Decide your next step based on your role, the task status, and other agents' contributions.
+
+#### 3. Act
+- Take your step. Always accompany it with an explanation or rationale.
+
+#### 4. Reflect
+- Reevaluate the action you just took.
+- Ask: Did it move the system forward? Was it clear? Do I need to correct or explain more?
+
+---
+
+### Section 5: Collaborative Behavioral Principles
+
+These principles guide your interaction with the rest of the system:
+
+1. **Transparency is default.** Share everything relevant unless explicitly told otherwise.
+2. **Ask when unsure.** Uncertainty should trigger clarification, not assumptions.
+3. **Build on others.** Treat peer contributions as assets to integrate, not noise to ignore.
+4. **Disagreement is normal.** If you disagree, explain your reasoning respectfully.
+5. **Silence is risky.** If no agents respond, prompt them or flag an alignment breakdown.
+6. **Operate as a system, not a silo.** Your output is only as useful as it is understood and usable by others.
+
+---
+
+### Example Phrases and Protocols
+
+- “Can we clarify the task completion criteria?”
+- “I will handle Step 2 and pass the result to Agent-4 for validation.”
+- “This step appears to be redundant; has it already been completed?”
+- “Let’s do a verification pass using the 3C protocol.”
+- “Agent-2, could you explain your logic before we proceed?”
+
+"#;

--- a/swarms-rs/src/structs/swarms_router.rs
+++ b/swarms-rs/src/structs/swarms_router.rs
@@ -1,0 +1,323 @@
+use dashmap::DashMap;
+use serde::Deserialize;
+
+use crate::agent::SwarmsAgent;
+use crate::llm::provider::openai::OpenAI;
+use crate::prompts::multi_agent_collab_prompt::MULTI_AGENT_COLLAB_PROMPT;
+use crate::structs::agent::Agent;
+use crate::structs::concurrent_workflow::ConcurrentWorkflow;
+use crate::structs::concurrent_workflow::ConcurrentWorkflowError;
+use crate::structs::conversation::AgentConversation;
+use crate::structs::sequential_workflow::SequentialWorkflow;
+use crate::structs::sequential_workflow::SequentialWorkflowError;
+
+/// The different allowed types of Swarms
+#[derive(Debug, Deserialize)]
+pub enum SwarmType {
+    SequentialWorkflow,
+    ConcurrentWorkflow,
+}
+
+/// Configuration model for SwarmsRouter
+pub struct SwarmRouterConfig {
+    /// Name identifier for the SwarmRouter instance.
+    pub name: String,
+
+    /// Description of the SwarmRouter's purpose.
+    pub description: String,
+
+    /// Type of swarm to use.
+    pub swarm_type: SwarmType,
+
+    /// List of the agents to use.
+    pub agents: Vec<SwarmsAgent<OpenAI>>,
+
+    /// Rules to inject in every agent
+    pub rules: Option<String>,
+
+    /// Whether to enable multi-agent collaboration prompts
+    pub multi_agent_collab_prompt: bool,
+}
+
+impl Default for SwarmRouterConfig {
+    fn default() -> SwarmRouterConfig {
+        SwarmRouterConfig {
+            name: String::from("swarm-router"),
+            description: String::from("Routes your task to the desired swarm"),
+            swarm_type: SwarmType::SequentialWorkflow,
+            agents: Vec::new(),
+            rules: None,
+            multi_agent_collab_prompt: true,
+        }
+    }
+}
+
+impl SwarmRouterConfig {
+    /// Ensure that all preconditions are met.
+    fn validate(&self) -> Result<(), SwarmRouterError> {
+        tracing::info!("Initializing reliability checks");
+        self.validate_agents()?;
+        tracing::info!("Reliability checks completed your swarm is ready");
+        Ok(())
+    }
+
+    /// Append the different rules provided by the user at the end of the prompt.
+    fn handle_rules(&mut self) {
+        let rules = match self.rules.as_deref() {
+            Some(rules) => rules,
+            None => return,
+        };
+
+        tracing::info!("Injecting rules to every agent!");
+        let agents = std::mem::take(&mut self.agents);
+        self.agents = agents
+            .into_iter()
+            .map(|agent| {
+                let system_prompt = agent.get_system_prompt().unwrap_or("");
+                let new_system_prompt = format!("{system_prompt}\n### SWARM RULES ###\n{rules}");
+                agent.system_prompt(new_system_prompt)
+            })
+            .collect();
+        tracing::info!("Finished injecting rules");
+    }
+
+    /// Activate automatic prompt engineering for agents that support it
+    fn update_system_prompt_for_agent_in_swarm(&mut self) {
+        tracing::info!("Injecting multi-agent prompt to every agent!");
+        let agents = std::mem::take(&mut self.agents);
+        self.agents = agents
+            .into_iter()
+            .map(|agent| {
+                let system_prompt = agent.get_system_prompt().unwrap_or("");
+                let new_system_prompt = format!("{system_prompt}\n{MULTI_AGENT_COLLAB_PROMPT}");
+                agent.system_prompt(new_system_prompt)
+            })
+            .collect();
+        tracing::info!("Finished injecting multi-agent prompt");
+    }
+
+    /// Validate that agents are valid
+    fn validate_agents(&self) -> Result<(), SwarmRouterError> {
+        if self.agents.is_empty() {
+            return Err(SwarmRouterError::ValidationError(String::from(
+                "No agents provided for the swarm.",
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+/// Struct that dynamically routes tasks to different swarm types based on user selection or automatic matching.
+/// The SwarmRouter enables flexible task execution by either using a specified swarm type or automatically determining
+/// the most suitable swarm type for a given task. It handles task execution while managing logging, type validation,
+/// and metadata capture.
+/// Available Swarm Types:
+///     - SequentialWorkflow: Executes tasks sequentially
+///     - ConcurrentWorkflow: Executes tasks in parallel
+pub enum SwarmRouter {
+    SequentialWorkflow(SequentialWorkflow),
+    ConcurrentWorkflow(ConcurrentWorkflow),
+}
+
+impl SwarmRouter {
+    /// Create a SwarmRouter from a SwarmConfig.
+    ///
+    ///  # Params
+    ///
+    ///  -  config: The configuration to initialize the SwarmRouter
+    ///
+    ///  # Returns:
+    ///
+    ///  - The configured and ready to execute SwarmRouter
+    ///
+    ///  # Error
+    ///     
+    ///  - SwarmRouterError::ValidationError: If fails during config validation
+    pub fn new_with_config(config: SwarmRouterConfig) -> Result<SwarmRouter, SwarmRouterError> {
+        config.validate()?;
+
+        tracing::info!(
+            "SwarmRouter initialized with swarm type: {:?}",
+            config.swarm_type
+        );
+
+        let mut config = config;
+        config.handle_rules();
+
+        if config.multi_agent_collab_prompt {
+            config.update_system_prompt_for_agent_in_swarm();
+        }
+
+        let swarm_router = SwarmRouter::create_swarm_router(config);
+        Ok(swarm_router)
+    }
+
+    ///  Execute a task on the selected swarm type with specified compute resources.
+    ///
+    ///  # Params
+    ///
+    ///  -  task: The task to be executed by the swarm.
+    ///
+    ///  # Returns:
+    ///
+    ///  - The result of the swarm's execution.
+    ///
+    ///  # Error
+    ///     
+    ///  - SwarmRouterError::ConcurrentWorkflow: If fails during execution of concurrent workflow
+    ///  - SwarmRouterError::ConcurrentWorkflow: If fails during execution of concurrent workflow
+    pub async fn run(&self, task: &str) -> Result<AgentConversation, SwarmRouterError> {
+        let result = self.inner_run(task).await;
+
+        if let Err(err) = &result {
+            tracing::error!("Error executing task on swarm: {err}");
+        }
+
+        result
+    }
+
+    /// Execute a batch of tasks on the selected or matched swarm type.
+    ///
+    /// # Params
+    ///
+    /// - tasks: A list of tasks to be executed by the swarm.
+    ///
+    /// # Returns:
+    ///
+    /// - A list of results from the swarm's execution.
+    ///
+    /// # Error
+    ///    
+    /// - SwarmRouterError::SequentialWorkflow: If fails during execution of sequential workflow for any of the tasks
+    /// - SwarmRouterError::ConcurrentWorkflow: If fails during execution of concurrent workflow for any of the tasks
+    pub async fn batch_run(
+        &self,
+        tasks: Vec<String>,
+    ) -> Result<DashMap<String, AgentConversation>, SwarmRouterError> {
+        let result = self.inner_batch_run(tasks).await;
+
+        if let Err(err) = &result {
+            tracing::error!("Error executing task on swarm: {err}");
+        }
+
+        result
+    }
+
+    async fn inner_run(&self, task: &str) -> Result<AgentConversation, SwarmRouterError> {
+        tracing::info!("Running task on {:?} swarm with task: {task}", self.kind());
+        let result = match self {
+            SwarmRouter::SequentialWorkflow(wf) => wf.run(task).await?,
+            SwarmRouter::ConcurrentWorkflow(wf) => wf.run(task).await?,
+        };
+        tracing::info!("Swarm completed successfully");
+
+        Ok(result)
+    }
+
+    async fn inner_batch_run(
+        &self,
+        tasks: Vec<String>,
+    ) -> Result<DashMap<String, AgentConversation>, SwarmRouterError> {
+        tracing::info!("Running batch tasks on {:?} swarm", self.kind());
+        let result = match self {
+            SwarmRouter::SequentialWorkflow(wf) => {
+                let results = DashMap::with_capacity(tasks.len());
+                for task in tasks {
+                    let result = wf.run(&task).await?;
+                    results.insert(task, result);
+                }
+                results
+            },
+            SwarmRouter::ConcurrentWorkflow(wf) => wf.run_batch(tasks).await?,
+        };
+        tracing::info!("Swarm completed successfully");
+
+        Ok(result)
+    }
+
+    fn kind(&self) -> SwarmType {
+        match self {
+            SwarmRouter::SequentialWorkflow(_) => SwarmType::SequentialWorkflow,
+            SwarmRouter::ConcurrentWorkflow(_) => SwarmType::ConcurrentWorkflow,
+        }
+    }
+
+    fn create_swarm_router(config: SwarmRouterConfig) -> SwarmRouter {
+        let agents = config
+            .agents
+            .into_iter()
+            .map(boxed_agent)
+            .collect::<Vec<_>>();
+
+        match config.swarm_type {
+            SwarmType::SequentialWorkflow => {
+                let workflow = SequentialWorkflow::builder()
+                    .name(config.name)
+                    .description(config.description)
+                    .agents(agents)
+                    .build();
+                SwarmRouter::SequentialWorkflow(workflow)
+            },
+            SwarmType::ConcurrentWorkflow => {
+                let workflow = ConcurrentWorkflow::builder()
+                    .name(config.name)
+                    .description(config.description)
+                    .agents(agents)
+                    .build();
+                SwarmRouter::ConcurrentWorkflow(workflow)
+            },
+        }
+    }
+}
+
+/// Create and run a SwarmRouter instance with the given configuration.
+///
+/// # Params
+///
+/// - task: Task to execute.
+/// - config: The SwarmConfig used to create the SwarmRouter
+///
+/// # Returns
+///
+/// - Result from executing the swarm router
+///
+/// # Error
+///
+/// - SwarmRouterError::ValidationError: If fails during config validation
+/// - SwarmRouterError::SequentialWorkflow: If fails during execution of sequential workflow
+/// - SwarmRouterError::ConcurrentWorkflow: If fails during execution of concurrent workflow
+pub async fn swarm_router(
+    task: &str,
+    config: SwarmRouterConfig,
+) -> Result<AgentConversation, SwarmRouterError> {
+    tracing::info!(
+        "Creating SwarmRouter with name: {}, swarm_type: {:?}",
+        config.name,
+        config.swarm_type
+    );
+
+    let router = SwarmRouter::new_with_config(config)?;
+    tracing::info!("Executing task with SwarmRouter: {}", task);
+
+    let result = router.run(task).await?;
+    tracing::info!("Task execution completed successfully");
+
+    Ok(result)
+}
+
+fn boxed_agent(agent: SwarmsAgent<OpenAI>) -> Box<dyn Agent> {
+    Box::new(agent)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SwarmRouterError {
+    #[error("SwarmRouter validation error: {0}")]
+    ValidationError(String),
+
+    #[error(transparent)]
+    SequentialWorkflowError(#[from] SequentialWorkflowError),
+
+    #[error(transparent)]
+    ConcurrentWorkflowError(#[from] ConcurrentWorkflowError),
+}


### PR DESCRIPTION
## Swarm Router

### Summary

The idea of this merge request (MR) is to add the SwarmRouter functionality from Python to Rust.

The code port is a subset of the whole functionality provided by Python SwarmRouter, as the Rust version still has some missing features and swarms to be implemented. This implementation tries to maintain as much as possible the names and functionality provided by the Python `SwarmRouter` feature, with the intend to make easier future ports of new functionality.

An example testing this functionality is also provided.

### Discussion

Here I open some discussion points about the implementation:
1. The Python implementation has a feature for storing logs in an array. This functionality is excluded from this MR, because I do not really understand the objective of that functionality in Python.
2. The Python implementation has different implementation for run, run_concurrent, run_async. In this implementation only one version is implemented, which is async. In the future, when more workflows are available, maybe it will make sense to include de `run_concurrent` version, to be able to execute any workflow/swarm concurrently.
3. The accepted agents by this implementation are of type `Vec<SwarmAgent<OpenAI>>`, maybe a more generic approach should be used as `Vec<Box<dyn Agent>>`. The main stopper for not implementing this functionality are the required methods `get_system_prompt` and `system_prompt`, required for prompt augmentation. Another possible approaches would be:

    1. To implement a new trait `PromptableAgent` with these 2 method methods
    2. To add these to methods to the `Agent` interface with a default implementation, to prevent broking existing interfaces.

Please, take a look at the discussion points before merging and lets decide what would be the best approach 😄 