### PR TITLE
[BUGF-TOOL][Fixed Tool Definitions not supporting annotating 'required,' despite it already being in docs]

### DIFF
--- a/swarms-rs/examples/tool.rs
+++ b/swarms-rs/examples/tool.rs
@@ -94,6 +94,18 @@ fn mul(x: f64, y: f64) -> Result<f64, CalcError> {
     Ok(x * y)
 }
 
+/// Example showing how to use the required field
+#[tool(
+    description = "Get weather information for a location",
+    arg(location, description = "City and country e.g. Bogotá, Colombia", required = true),
+    arg(unit, description = "Temperature unit (celsius or fahrenheit)", required = false)
+)]
+fn get_weather(location: String, unit: Option<String>) -> Result<String, CalcError> {
+    tracing::info!("Get weather tool is called with location: {}, unit: {:?}", location, unit);
+    let unit = unit.unwrap_or_else(|| "celsius".to_string());
+    Ok(format!("Weather in {}: 25°{}", location, unit))
+}
+
 /// This shows how to use a struct as parameter.
 /// We can describe the field of the struct, just see the `ExecShell` struct.
 #[tool(description = "
@@ -115,6 +127,31 @@ struct ExecShell {
     don_t_tell_you_what_it_means_2: bool,
     /// Who wants to execute the command
     don_t_tell_you_what_it_means_3: String,
+}
+
+/// Example struct with required and optional fields
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct UserProfile {
+    /// The user's name (required)
+    name: String,
+    /// The user's age (required)
+    age: u32,
+    /// The user's email (optional)
+    #[serde(default)]
+    email: Option<String>,
+    /// The user's bio (optional)
+    #[serde(default)]
+    bio: Option<String>,
+}
+
+/// Example tool using a struct with required and optional fields
+#[tool(description = "Create a user profile")]
+fn create_user_profile(profile: UserProfile) -> Result<String, CalcError> {
+    tracing::info!("Create user profile tool is called");
+    let email = profile.email.unwrap_or_else(|| "No email provided".to_string());
+    let bio = profile.bio.unwrap_or_else(|| "No bio provided".to_string());
+    Ok(format!("Created profile for {} (age: {}) with email: {} and bio: {}", 
+               profile.name, profile.age, email, bio))
 }
 
 /// ## IMPORTANT


### PR DESCRIPTION
## Description
Added support for the `required` property in Tool Definitions for the Rust implementation. Previously, the `#[tool]` macro did not support annotating which function arguments are required, even though the documentation and other providers (like OpenAI) support this functionality.

## Core Files Changed
- `swarms-macro/src/tool.rs` - Enhanced macro implementation to support required field parsing and JSON schema generation
- `swarms-rs/examples/tool.rs` - Added examples demonstrating the new required field functionality

## Issue
The ToolDefinition struct and the `#[tool]` macro were missing support for the `required` property, which is essential for:
- Proper API documentation
- Better LLM understanding of parameter requirements
- Compliance with OpenAI's function calling specification
- Improved error handling and validation

## What Was Wrong
1. **Missing Required Field Support**: The `ArgMeta` struct only had `name` and `description` fields, but no `required` field
2. **Incomplete JSON Schema Generation**: The generated JSON schema did not include the `required` array
3. **Documentation Mismatch**: The documentation showed examples with required fields, but the Rust implementation couldn't handle them
4. **Validation Issues**: No validation to ensure optional arguments are properly typed as `Option<T>`

## Technical Implementation

### Before (Missing Required Support):
```rust
#[derive(Debug)]
struct ArgMeta {
    name: String,
    description: Option<String>,
    // Missing: required: Option<bool>
}

// Generated JSON schema without required array:
parameters: serde_json::json!({
    "type": "object",
    "properties": {
        "location": {
            "type": "string",
            "description": "City and country"
        }
    }
    // Missing: "required": ["location"]
})
```

### After (With Required Support):
```rust
#[derive(Debug)]
struct ArgMeta {
    name: String,
    description: Option<String>,
    required: Option<bool>,  // NEW: Support for required field
}

// Enhanced parsing for required attribute:
"required" => {
    let lit = syn::parse2::<syn::LitBool>(nv.value.into_token_stream())
        .map_err(|e| {
            Error::new_spanned(
                value,
                format!("Expected boolean literal (true/false) for 'required' attribute, got: {}", e),
            )
        })?;
    arg.required = Some(lit.value);
}

// Generated JSON schema with required array:
parameters: serde_json::json!({
    "type": "object",
    "properties": {
        "location": {
            "type": "string",
            "description": "City and country"
        }
    },
    "required": ["location"]  // NEW: Required array included
})
```

### Usage Example:
```rust
#[tool(
    description = "Get weather information for a location",
    arg(location, description = "City and country e.g. Bogotá, Colombia", required = true),
    arg(unit, description = "Temperature unit (celsius or fahrenheit)", required = false)
)]
fn get_weather(location: String, unit: Option<String>) -> Result<String, CalcError> {
    let unit = unit.unwrap_or_else(|| "celsius".to_string());
    Ok(format!("Weather in {}: 25°{}", location, unit))
}
```

## Dependencies
No new dependencies required. Uses existing `syn` crate for parsing boolean literals.

## Validation Added
```rust
// Validate that optional arguments are Option types
for arg in &tool_attr.args {
    if let Some(false) = arg.required {
        if let Some((_, ty)) = args.clone().find(|(pat, _)| {
            if let syn::Pat::Ident(pat_ident) = &***pat {
                pat_ident.ident == arg.name
            } else {
                false
            }
        }) {
            if let Type::Path(type_path) = &**ty {
                let segment = &type_path.path.segments[0];
                if segment.ident != "Option" {
                    panic!("Argument '{}' is marked as optional (required = false) but is not an Option type", arg.name);
                }
            }
        }
    }
}
```

## Backward Compatibility
- All existing code continues to work without changes
- Arguments are required by default (maintains existing behavior)
- Only arguments explicitly marked with `required = false` are treated as optional

## Tag maintainer
@kyegomez 

## Twitter handle
https://[x.com/IlumTheProtogen](https://x.com/IlumTheProtogen)