### PR TITLE
reduce logging case to increase performance

### DIFF
--- a/swarms-rs/src/agent/swarms_agent.rs
+++ b/swarms-rs/src/agent/swarms_agent.rs
@@ -446,7 +446,7 @@ where
     }
 
     pub fn build(mut self) -> SwarmsAgent<M> {
-        if self.config.verbose {
+        if self.config.verbose && log::log_enabled!(log::Level::Info) {
             log::info!(
                 "🏗️  Building SwarmsAgent: {}",
                 self.config.name.bright_cyan().bold()
@@ -476,7 +476,7 @@ where
             tools_impl: self.tools_impl,
         };
 
-        if agent.config.verbose {
+        if agent.config.verbose && log::log_enabled!(log::Level::Info) {
             log::info!(
                 "✅ SwarmsAgent built successfully: {} (ID: {}) with {} tools",
                 agent.config.name.bright_cyan().bold(),

--- a/swarms-rs/src/structs/agent.rs
+++ b/swarms-rs/src/structs/agent.rs
@@ -232,11 +232,11 @@ impl Default for AgentConfig {
             stop_words: HashSet::with_capacity(16), // Pre-allocate capacity
             task_evaluator_tool_enabled: true,
             concurrent_tool_call_enabled: true,
-            verbose: true, // Default to verbose logging
+            verbose: false, // Default to verbose logging
             response_cache: HashMap::with_capacity(100), // Pre-allocate cache capacity
         };
         
-        if config.verbose {
+        if config.verbose && log::log_enabled!(log::Level::Debug) {
             log::debug!(
                 "🆕 Creating default agent configuration with ID: {}",
                 id.bright_yellow()


### PR DESCRIPTION
This PR optimizes agent initialization by reducing unnecessary logging overhead. Previously, every log::debug! and log::info! statement evaluated expensive string formatting (ANSI colors, UUID formatting) even when the log level was disabled. 

🔧 Changes

Default AgentConfig.verbose set to false (opt-in logging).

Wrapped all initialization logs with log::log_enabled! to avoid expensive formatting when logs are disabled.

Fixes #48
