### PR TITLE
fix: build binance-tools - pin rmcp to v0.9.1 due to SSE transport removal

### DIFF
--- a/examples/binance-tools/Cargo.toml
+++ b/examples/binance-tools/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 chrono = "0.4"
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+rmcp = { version = "0.9.1", features = [
     "server",
     "macros",
     "transport-io",


### PR DESCRIPTION
# Pull Request

## Description

Fix the broken build of the entire swarms-rs workspace by fixing the binance-tools example. The binance-tools package was the blocking dependency that prevented the entire workspace from building.

**Root Cause**: The binance-tools example uses `SseServer` from `rmcp`, which requires the `transport-sse-server` feature. The upstream rust-sdk removed SSE transport support in commit eb5a7f7 (released in rmcp v0.11.0).

**Breaking Commit**: https://github.com/modelcontextprotocol/rust-sdk/commit/eb5a7f74080e086edd99c1324b4d77bde82ff033

(Since the above commit was pushed on 2nd Dec, I imagine the build for `swarms-rs` repo has been broken since 25 days)

**Solution**: Pin the `rmcp` dependency to version 0.9.1, which is the last version that includes SSE transport support and the `transport-sse-server` feature.

**Impact**: 
- ✅ binance-tools build fixed
- ✅ swarms-rs workspace build fixed (binance-tools was the blocking package)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Maintenance (refactoring, performance improvements, etc.)
- [ ] 🧪 Tests (adding or improving tests)
- [ ] 🚀 CI/CD (changes to build, CI, or deployment processes)

## Related Issues

This fix addresses the build failure that occurred after the rust-sdk removed SSE transport support.

Reference: https://github.com/modelcontextprotocol/rust-sdk/pull/562 (commit eb5a7f7)

## Changes Made

- Updated `examples/binance-tools/Cargo.toml` to pin `rmcp` to version 0.9.1
- Changed from git dependency (main branch) to fixed version 0.9.1
- Version 0.9.1 is the last version that includes SSE transport support and the `transport-sse-server` feature
- **Impact**: Fixes binance-tools build, which unblocks the entire swarms-rs workspace build

## Testing

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

### Test Details

```bash
# Build binance-tools successfully
cargo build --package binance-tools

# Build entire workspace successfully (previously failed)
cargo build --workspace

# Code passes checks
cargo check --package binance-tools

# Linting checks pass
cargo clippy --package binance-tools
```

Build output:
```
   Compiling binance-tools v0.1.0 (/Users/revant.gupta/gh-repos/swarms/swarms-rs/examples/binance-tools)
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.95s
```

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (please explain)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes (please describe below)

### Migration Guide

N/A

## Documentation

- [ ] Documentation updated (if needed)
- [ ] Examples updated (if needed)
- [ ] README updated (if needed)
- [ ] Changelog updated

## Security

- [x] No security implications
- [ ] Security considerations addressed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The binance-tools example uses `SseServer` from rmcp, which requires the `transport-sse-server` feature. This feature was removed in rmcp v0.11.0 (commit eb5a7f7 in the rust-sdk repository). By pinning to v0.9.1, we restore compatibility with the SSE transport.

**Workspace Impact**: Since binance-tools was the only package preventing the entire swarms-rs workspace from building, fixing binance-tools unblocks the complete workspace build. This was the primary objective of this fix.

Future consideration: Migrate binance-tools to use the new transport method supported by rmcp ≥0.11.0 (streamable-http) to allow updating to the latest rmcp version.

## Reviewer Notes

This is a minimal, focused fix that addresses the immediate build failure by pinning to a compatible version. The change is:
- 1 file modified: `examples/binance-tools/Cargo.toml`
- 1 line changed (dependency version)
- No functional code changes
- Build, check, and clippy all pass

---

**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.*