### PR TITLE
fix: handle empty tool_calls array from OpenAI-compatible providers

### DIFF
--- a/swarms-rs/src/llm/provider/openai.rs
+++ b/swarms-rs/src/llm/provider/openai.rs
@@ -478,14 +478,20 @@ impl From<async_openai::types::CreateChatCompletionResponse>
             .flat_map(|choice| {
                 let content = choice.message.content.to_owned();
                 let tool_calls = choice.message.tool_calls.to_owned();
-                // OpenAI should always return content or tool_calls
-                if tool_calls.is_none() {
-                    let content =
-                        content.expect("OpenAI should always return content or tool_calls");
-                    vec![llm::completion::AssistantContent::text(content)]
+
+                // Check if tool_calls has actual calls (some providers like DeepInfra return empty array instead of None)
+                let has_tool_calls = tool_calls.as_ref().is_some_and(|tc| !tc.is_empty());
+
+                if !has_tool_calls {
+                    // Return text content if no tool calls
+                    if let Some(content) = content {
+                        vec![llm::completion::AssistantContent::text(content)]
+                    } else {
+                        vec![]
+                    }
                 } else {
-                    let tool_calls = tool_calls.expect("We just checked that it is not None");
-                    let tool_calls = tool_calls
+                    let tool_calls = tool_calls.expect("We just checked that it is not empty");
+                    tool_calls
                         .iter()
                         .map(|tool_call| {
                             llm::completion::AssistantContent::tool_call(
@@ -495,8 +501,7 @@ impl From<async_openai::types::CreateChatCompletionResponse>
                                     .expect("OpenAI return invalid json"),
                             )
                         })
-                        .collect::<Vec<_>>();
-                    tool_calls
+                        .collect::<Vec<_>>()
                 }
             })
             .collect::<Vec<_>>();

--- a/swarms-rs/tests/test_openai_compatible_providers.rs
+++ b/swarms-rs/tests/test_openai_compatible_providers.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use swarms_rs::{llm::provider::openai::OpenAI, structs::agent::Agent};
+
+/// Test DeepInfra provider compatibility
+///
+/// This test verifies that the agent works correctly with DeepInfra,
+/// which returns empty `tool_calls: []` arrays instead of `None`.
+#[tokio::test]
+async fn test_deepinfra_agent() -> Result<()> {
+    // Skip test if environment variables are not set
+    if std::env::var("DEEPINFRA_BASE_URL").is_err() || std::env::var("DEEPINFRA_API_KEY").is_err() {
+        println!("Skipping test_deepinfra_agent: DEEPINFRA env vars not set");
+        return Ok(());
+    }
+
+    dotenv::dotenv().ok();
+
+    let base_url = std::env::var("DEEPINFRA_BASE_URL").unwrap();
+    let api_key = std::env::var("DEEPINFRA_API_KEY").unwrap();
+
+    let client = OpenAI::from_url(base_url, api_key).set_model("meta-llama/Llama-3.3-70B-Instruct");
+
+    let agent = client
+        .agent_builder()
+        .system_prompt("You are a helpful assistant.")
+        .agent_name("DeepInfraAgent")
+        .user_name("TestUser")
+        .max_loops(1)
+        .disable_task_complete_tool()
+        .build();
+
+    let response = agent.run("What is 2+2? Answer with just the number.".to_owned()).await?;
+
+    assert!(!response.is_empty(), "Response should not be empty");
+    assert!(
+        response.contains("4"),
+        "Response should contain the answer '4'"
+    );
+
+    Ok(())
+}
+
+/// Test OpenAI provider compatibility
+#[tokio::test]
+async fn test_openai_agent() -> Result<()> {
+    // Skip test if environment variables are not set
+    if std::env::var("OPENAI_BASE_URL").is_err() || std::env::var("OPENAI_API_KEY").is_err() {
+        println!("Skipping test_openai_agent: OPENAI env vars not set");
+        return Ok(());
+    }
+
+    dotenv::dotenv().ok();
+
+    let base_url = std::env::var("OPENAI_BASE_URL").unwrap();
+    let api_key = std::env::var("OPENAI_API_KEY").unwrap();
+
+    let client = OpenAI::from_url(base_url, api_key).set_model("gpt-4o-mini");
+
+    let agent = client
+        .agent_builder()
+        .system_prompt("You are a helpful assistant.")
+        .agent_name("OpenAIAgent")
+        .user_name("TestUser")
+        .max_loops(1)
+        .disable_task_complete_tool()
+        .build();
+
+    let response = agent.run("What is 2+2? Answer with just the number.".to_owned()).await?;
+
+    assert!(!response.is_empty(), "Response should not be empty");
+    assert!(
+        response.contains("4"),
+        "Response should contain the answer '4'"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Some providers like DeepInfra return an empty `tool_calls: []` array instead of `None` when no tools are called. This caused a panic because the code assumed that if `tool_calls` was `Some`, it would contain at least one tool call.

This fix checks if the array is actually non-empty before processing tool calls, falling back to text content extraction otherwise.

Fixes compatibility with DeepInfra and other OpenAI-compatible APIs.

# Pull Request

## Description

Some OpenAI-compatible providers like DeepInfra return an empty `tool_calls: []` array instead of `None` when the model doesn't call any tools. This caused the agent to fail with "No choice found" error because the code assumed that if `tool_calls` was `Some`, it would contain at least one tool call.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Tests (adding or improving tests)

## Related Issues

N/A

## Changes Made

- Modified `From<CreateChatCompletionResponse>` in `swarms-rs/src/llm/provider/openai.rs`
- Used `is_some_and(|tc| !tc.is_empty())` to check for actual tool calls before processing
- Added integration tests for DeepInfra and OpenAI providers in `swarms-rs/tests/test_openai_compatible_providers.rs`

## Testing

### Test Coverage

- [x] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

### Test Details

```bash
# Run integration tests (requires env vars)
DEEPINFRA_BASE_URL=... DEEPINFRA_API_KEY=... cargo test test_deepinfra_agent
OPENAI_BASE_URL=... OPENAI_API_KEY=... cargo test test_openai_agent
