### PR TITLE
perf: trim tokio features from "full" to selective

### DIFF
--- a/swarms-rs/Cargo.toml
+++ b/swarms-rs/Cargo.toml
@@ -21,7 +21,7 @@ futures = "0.3"
 uuid = { version = "1.15", features = ["v4", "serde"] }
 url = "2.5"
 tokio-rustls = "0.26.2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "fs", "io-util", "signal"] }
 thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
## Summary
Replaces `tokio = { features = ["full"] }` with only the features the codebase actually uses.

Part of #57

## Changes
```toml
# Before
tokio = { version = "1", features = ["full"] }

# After
tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "fs", "io-util", "signal"] }
```

## Why
- `"full"` includes `tokio::net` (TCP/UDP), `tokio::process`, and `tokio::io` stdout/stdin — none of which are used in `swarms-rs/src/`
- Selective features reduce compile time and binary size
- Verified: `grep -rn "tokio::net\|tokio::process" src/` returns no results

## What's NOT included (intentionally)
- `net` — no TCP/UDP listeners or streams in src
- `process` — no child process spawning in src
- `io-std` — no stdin/stdout async wrappers in src

This is the first of the optimizations suggested in #57. Additional improvements (logging consolidation, hyper/reqwest dedup) can follow as separate PRs.